### PR TITLE
fix(KONFLUX-9989): disable fips tasks

### DIFF
--- a/.tekton/fbc-fips-check-oci-ta-v01-pull-request.yaml
+++ b/.tekton/fbc-fips-check-oci-ta-v01-pull-request.yaml
@@ -8,9 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "task/fbc-fips-check-oci-ta/0.1/***".pathChanged() || ".tekton/fbc-fips-check-oci-ta-v01-pull-request.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: 'false'
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fbc-fips-check-oci-ta-v01-push.yaml
+++ b/.tekton/fbc-fips-check-oci-ta-v01-push.yaml
@@ -7,9 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/fbc-fips-check-oci-ta/0.1/***".pathChanged() || ".tekton/fbc-fips-check-oci-ta-v01-pull-request.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: 'false'
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fbc-fips-check-v01-pull-request.yaml
+++ b/.tekton/fbc-fips-check-v01-pull-request.yaml
@@ -8,9 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "task/fbc-fips-check/0.1/***".pathChanged() || ".tekton/fbc-fips-check-v01-pull-request.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: 'false'
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fbc-fips-check-v01-push.yaml
+++ b/.tekton/fbc-fips-check-v01-push.yaml
@@ -7,9 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/fbc-fips-check/0.1/***".pathChanged() || ".tekton/fbc-fips-check-v01-pull-request.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: 'false'
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fips-operator-bundle-check-v01-pull-request.yaml
+++ b/.tekton/fips-operator-bundle-check-v01-pull-request.yaml
@@ -8,9 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "task/fips-operator-bundle-check/0.1/***".pathChanged() || ".tekton/fips-operator-bundle-check-v01-pull-request.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: 'false'
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fips-operator-bundle-check-v01-push.yaml
+++ b/.tekton/fips-operator-bundle-check-v01-push.yaml
@@ -7,9 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/fips-operator-bundle-check/0.1/***".pathChanged() || ".tekton/fips-operator-bundle-check-v01-pull-request.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: 'false'
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks


### PR DESCRIPTION
The reason for this change is to prevent updates in the FIPS tasks from pushing new tags to:
https://quay.io/repository/konflux-ci/tekton-catalog/task-fbc-fips-check-oci-ta?tab=tags&tag=latest

Sometimes the konflux-operator-tasks tasks are not aligned with build-definitions, and new tags could result in downgrading the check-payload version.

We would like to keep the build-definitions repo as the source of truth for these tasks.

More in this Slack thread: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1756886714271399
