### PR TITLE
fix: limit push builds to task/ directory changes

### DIFF
--- a/.tekton/fbc-target-index-pruning-check-v01-push.yaml
+++ b/.tekton/fbc-target-index-pruning-check-v01-push.yaml
@@ -8,9 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/fbc-target-index-pruning-check/0.1/***".pathChanged() ||
-      ".tekton/fbc-target-index-pruning-check-v01-pull-request.yaml".pathChanged()
-      )
+      == "main" && "/task/fbc-target-index-pruning-check/0.1/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/sbom-json-check-v01-push.yaml
+++ b/.tekton/sbom-json-check-v01-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/sbom-json-check/0.1/***".pathChanged() || ".tekton/sbom-json-check-v01-pull-request.yaml".pathChanged()
-      )
+      == "main" && "/task/sbom-json-check/0.1/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/sbom-json-check-v02-push.yaml
+++ b/.tekton/sbom-json-check-v02-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/sbom-json-check/0.2/***".pathChanged() || ".tekton/sbom-json-check-v02-pull-request.yaml".pathChanged()
-      )
+      == "main" && "/task/sbom-json-check/0.2/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/validate-fbc-v01-push.yaml
+++ b/.tekton/validate-fbc-v01-push.yaml
@@ -8,8 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "task/validate-fbc/0.1/***".pathChanged() || ".tekton/validate-fbc-v01-pull-request.yaml".pathChanged()
-      )
+      == "main" && "/task/validate-fbc/0.1/***".pathChanged()
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks


### PR DESCRIPTION
Limit the push pipeline runs to changes on the task files to avoid unnecessary noise republishing the same task over and over again

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
