### PR TITLE
feat(CLOUDDST-32569): Check bundle images are pinned by digest

### DIFF
--- a/task/validate-fbc/0.1/TROUBLESHOOTING.md
+++ b/task/validate-fbc/0.1/TROUBLESHOOTING.md
@@ -19,3 +19,15 @@ You can choose to produce `olm.csv.metadata` format by using the `--migrate-leve
 Bundle data in `olm.csv.metadata` format contains only information that the OpenShift Console needs which is derived from the package's Cluster Standard Version(CSV).  Since the previous `olm.bundle.object` format would include bundle CSV metadata as well as other properties it is possible to convert from `olm.bundle.object` to `olm.csv.metadata`, but not the reverse. 
 
 If you rely on other tooling/processes to produce your fragment and currently use the `olm.bundle.object` bundle metadata format, then you may either adjust your tooling to generate `olm.csv.metadata` format or you may use `opm` to migrate your fragment's bundle metadata by using `opm render --migrate-level=bundle-object-to-csv-metadata [fragment-ref]` (where `fragment-ref` is a pullspec to the fragment or a path to a directory containing the fragment).
+
+## olm.bundle image references are not digest-pinned
+
+Tasks may fail with an error message containing the string `olm.bundle image references are not digest-pinned`. This means that one or more bundle image references in your FBC fragment use a floating tag (e.g. `:latest` or `:v1.0`) instead of a digest-pinned reference.
+
+All `olm.bundle` image references must use the `@sha256:<digest>` format to ensure reproducible builds and supply chain integrity.
+
+To fix this, replace tag-based references with their digest-pinned equivalents. You can obtain the digest for an image using:
+```bash
+skopeo inspect --no-tags docker://<image>:<tag> | jq -r '.Digest'
+```
+Then update your catalog to use `<image>@sha256:<digest>` instead of `<image>:<tag>`.

--- a/task/validate-fbc/0.1/TROUBLESHOOTING.md
+++ b/task/validate-fbc/0.1/TROUBLESHOOTING.md
@@ -31,3 +31,11 @@ To fix this, replace tag-based references with their digest-pinned equivalents. 
 skopeo inspect --no-tags docker://<image>:<tag> | jq -r '.Digest'
 ```
 Then update your catalog to use `<image>@sha256:<digest>` instead of `<image>:<tag>`.
+
+## olm.bundle image references are not from registry.redhat.io or registry.stage.redhat.io
+
+Tasks may fail with an error message containing the string `olm.bundle image references are not from registry.redhat.io or registry.stage.redhat.io`. This means that one or more bundle image references in your FBC fragment point to a registry other than `registry.redhat.io` or `registry.stage.redhat.io`.
+
+All `olm.bundle` image references must originate from a trusted registry to ensure supply chain integrity.
+
+To fix this, ensure that all bundle images referenced in your catalog are published to `registry.redhat.io` or `registry.stage.redhat.io` and update the image references accordingly.

--- a/task/validate-fbc/0.1/USAGE.md
+++ b/task/validate-fbc/0.1/USAGE.md
@@ -36,6 +36,9 @@ To validate bundle metadata, the test evaluates bundle metadata usage against th
 - for 4.16 and earlier, fragments must use `olm.bundle.object` (and not use `olm.csv.metadata`)
 - for 4.17 and later, fragments must use `olm.csv.metadata` (and not use `olm.bundle.object`)
 
+### Digest-pinned bundle image references
+To validate supply chain integrity and ensure reproducible builds, all `olm.bundle` image references in the rendered catalog must be digest-pinned, i.e. use the `@sha256:<digest>` format rather than a floating tag. Any non-pinned reference causes a validation failure.
+
 ## Data output
 ### Related images
 

--- a/task/validate-fbc/0.1/USAGE.md
+++ b/task/validate-fbc/0.1/USAGE.md
@@ -39,6 +39,9 @@ To validate bundle metadata, the test evaluates bundle metadata usage against th
 ### Digest-pinned bundle image references
 To validate supply chain integrity and ensure reproducible builds, all `olm.bundle` image references in the rendered catalog must be digest-pinned, i.e. use the `@sha256:<digest>` format rather than a floating tag. Any non-pinned reference causes a validation failure.
 
+### Trusted registry for bundle image references
+To validate that bundle images originate from trusted sources, all `olm.bundle` image references must come from `registry.redhat.io` or `registry.stage.redhat.io`. References pointing to any other registry cause a validation failure.
+
 ## Data output
 ### Related images
 

--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -331,8 +331,8 @@ spec:
         mv "$OPM_BINARY" /shared/bin/opm
         export PATH=/shared/bin:$PATH
 
-        # We have 10 total checks
-        check_num=10
+        # We have 11 total checks
+        check_num=11
         failure_num=0
         TESTPASSED=true
 
@@ -466,6 +466,33 @@ spec:
             failure_num=$((failure_num + 1))
               TESTPASSED=false
             fi
+          fi
+        fi
+
+        # Validate olm.bundle image references are digest-pinned
+        status=0
+        bundle_images=$(jq -r 'select(.schema == "olm.bundle" and .image != null) | .image' ${OPM_RENDERED_CATALOG}) || status=$?
+        if [ $status -ne 0 ]; then
+          echo "!FAILURE! - Could not extract olm.bundle image references from rendered catalog."
+          failure_num=$((failure_num + 1))
+          TESTPASSED=false
+        else
+          digest_pinned_regex='@sha256:[a-fA-F0-9]{64}$'
+          non_pinned_images=()
+
+          while IFS= read -r bundle_image; do
+            if [[ -n "${bundle_image}" ]]; then
+              if [[ ! "${bundle_image}" =~ ${digest_pinned_regex} ]]; then
+                non_pinned_images+=("${bundle_image}")
+              fi
+            fi
+          done <<< "${bundle_images}"
+
+          if [[ ${#non_pinned_images[@]} -gt 0 ]]; then
+            echo "!FAILURE! - The following olm.bundle image references are not digest-pinned:"
+            printf '  %s\n' "${non_pinned_images[@]}"
+            failure_num=$((failure_num + 1))
+            TESTPASSED=false
           fi
         fi
 

--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -331,8 +331,8 @@ spec:
         mv "$OPM_BINARY" /shared/bin/opm
         export PATH=/shared/bin:$PATH
 
-        # We have 11 total checks
-        check_num=11
+        # We have 12 total checks
+        check_num=12
         failure_num=0
         TESTPASSED=true
 
@@ -469,21 +469,27 @@ spec:
           fi
         fi
 
-        # Validate olm.bundle image references are digest-pinned
+        # Validate olm.bundle image references are digest-pinned and from trusted registries
         status=0
         bundle_images=$(jq -r 'select(.schema == "olm.bundle" and .image != null) | .image' ${OPM_RENDERED_CATALOG}) || status=$?
         if [ $status -ne 0 ]; then
           echo "!FAILURE! - Could not extract olm.bundle image references from rendered catalog."
-          failure_num=$((failure_num + 1))
+          echo "Skipping digest-pinning and trusted-registry checks."
+          failure_num=$((failure_num + 2))
           TESTPASSED=false
         else
           digest_pinned_regex='@sha256:[a-fA-F0-9]{64}$'
+          trusted_registry_regex='^registry\.(stage\.)?redhat\.io/'
           non_pinned_images=()
+          wrong_registry_images=()
 
           while IFS= read -r bundle_image; do
             if [[ -n "${bundle_image}" ]]; then
               if [[ ! "${bundle_image}" =~ ${digest_pinned_regex} ]]; then
                 non_pinned_images+=("${bundle_image}")
+              fi
+              if [[ ! "${bundle_image}" =~ ${trusted_registry_regex} ]]; then
+                wrong_registry_images+=("${bundle_image}")
               fi
             fi
           done <<< "${bundle_images}"
@@ -491,6 +497,13 @@ spec:
           if [[ ${#non_pinned_images[@]} -gt 0 ]]; then
             echo "!FAILURE! - The following olm.bundle image references are not digest-pinned:"
             printf '  %s\n' "${non_pinned_images[@]}"
+            failure_num=$((failure_num + 1))
+            TESTPASSED=false
+          fi
+
+          if [[ ${#wrong_registry_images[@]} -gt 0 ]]; then
+            echo "!FAILURE! - The following olm.bundle image references are not from registry.redhat.io or registry.stage.redhat.io:"
+            printf '  %s\n' "${wrong_registry_images[@]}"
             failure_num=$((failure_num + 1))
             TESTPASSED=false
           fi


### PR DESCRIPTION
Add checks whether the olm.bundle reference is digest pinned and referenced from registry.redhat.io or registry.stage.redhat.io.

Related [PR](https://github.com/konflux-ci/build-definitions/pull/3579) and the review (old repository)


### Risk assessment 
Medium

New restriction is applied (digest and registry reference), meaning all of the bundles that do not fulfill this restriction will cause the builds to fail.

In case of failing bug, teams can file a Conforma exception to unblock the release.