### PR TITLE
Revert "fix(KONFLUX-9989): disable fips tasks"

### DIFF
--- a/.tekton/fbc-fips-check-oci-ta-v01-pull-request.yaml
+++ b/.tekton/fbc-fips-check-oci-ta-v01-pull-request.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: 'false'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "task/fbc-fips-check-oci-ta/0.1/***".pathChanged() || ".tekton/fbc-fips-check-oci-ta-v01-pull-request.yaml".pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fbc-fips-check-oci-ta-v01-push.yaml
+++ b/.tekton/fbc-fips-check-oci-ta-v01-push.yaml
@@ -7,7 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: 'false'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "task/fbc-fips-check-oci-ta/0.1/***".pathChanged() || ".tekton/fbc-fips-check-oci-ta-v01-pull-request.yaml".pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fbc-fips-check-v01-pull-request.yaml
+++ b/.tekton/fbc-fips-check-v01-pull-request.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: 'false'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "task/fbc-fips-check/0.1/***".pathChanged() || ".tekton/fbc-fips-check-v01-pull-request.yaml".pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fbc-fips-check-v01-push.yaml
+++ b/.tekton/fbc-fips-check-v01-push.yaml
@@ -7,7 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: 'false'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "task/fbc-fips-check/0.1/***".pathChanged() || ".tekton/fbc-fips-check-v01-pull-request.yaml".pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fips-operator-bundle-check-v01-pull-request.yaml
+++ b/.tekton/fips-operator-bundle-check-v01-pull-request.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: 'false'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main" && ( "task/fips-operator-bundle-check/0.1/***".pathChanged() || ".tekton/fips-operator-bundle-check-v01-pull-request.yaml".pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks

--- a/.tekton/fips-operator-bundle-check-v01-push.yaml
+++ b/.tekton/fips-operator-bundle-check-v01-push.yaml
@@ -7,7 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: 'false'
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main" && ( "task/fips-operator-bundle-check/0.1/***".pathChanged() || ".tekton/fips-operator-bundle-check-v01-pull-request.yaml".pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: konflux-operator-tasks


### PR DESCRIPTION
This reverts commit 2ad4234adbc067300e7ae1d69ec97b378699fe72.

This enables building and releasing FBC FIPS task bundles

