### PR TITLE
feat(run-opm-command-oci-ta): add computeResources to all steps

### DIFF
--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -73,12 +73,6 @@ spec:
   steps:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
-      computeResources:
-        limits:
-          memory: 4Gi
-        requests:
-          cpu: 50m
-          memory: 4Gi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -336,12 +330,6 @@ spec:
           replace_mirror_pullspec_with_source "${IDMS_PATH_PARAM}" "${FILE_TO_UPDATE_PULLSPEC_PATH}"
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
-      computeResources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: 50m
-          memory: 3Gi
       when:
         - input: "$(steps.run-opm-with-user-args.results.skip_create_trusted_artifact)"
           operator: in

--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -73,11 +73,23 @@ spec:
   steps:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 50m
+          memory: 4Gi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: run-opm-with-user-args
       image: quay.io/konflux-ci/operator-sdk-builder:latest@sha256:2737ff035f3a6d94e189cd31e7653998525c52f4d4db994ba1874a3a74bb4912
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       workingDir: /var/workdir/source
       results:
         - name: skip_create_trusted_artifact
@@ -133,6 +145,12 @@ spec:
         - $(params.OPM_ARGS[*])
     - name: convert-image-tags-to-digests
       image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 250m
+          memory: 64Mi
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0
@@ -278,6 +296,12 @@ spec:
         convert_tags_to_digests
     - name: replace-related-images-pullspec-in-file
       image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0
@@ -312,6 +336,12 @@ spec:
           replace_mirror_pullspec_with_source "${IDMS_PATH_PARAM}" "${FILE_TO_UPDATE_PULLSPEC_PATH}"
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: 50m
+          memory: 3Gi
       when:
         - input: "$(steps.run-opm-with-user-args.results.skip_create_trusted_artifact)"
           operator: in

--- a/task/run-opm-command-oci-ta/CHANGELOG.md
+++ b/task/run-opm-command-oci-ta/CHANGELOG.md
@@ -11,7 +11,7 @@ If that's not something you ever plan to do, consider removing this section.
 
 ### Added
 
-- Added computeResources to all steps.
+- Added computeResources to all task-specific steps.
 
 ## 0.1
 

--- a/task/run-opm-command-oci-ta/CHANGELOG.md
+++ b/task/run-opm-command-oci-ta/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
+
+## Unreleased
+
+<!--
+When you make changes without bumping the version right away, document them here.
+If that's not something you ever plan to do, consider removing this section.
+-->
+
+### Added
+
+- Added computeResources to all steps.
+
+## 0.1
+
+### Added
+
+- The initial version of the `run-opm-command-oci-ta` task!


### PR DESCRIPTION
## Summary

This PR adds explicit `computeResources` to all task-specific steps of the `run-opm-command-oci-ta` task, per the Konflux resource policy:
- `memory.request == memory.limit`
- `cpu.request` set, no `cpu.limit`

> **Note:** This work was originally raised as [konflux-ci/build-definitions#3570](https://github.com/konflux-ci/build-definitions/pull/3570), but has been re-opened here following the migration of all FBC tasks to this repository.

## Changes

| Step | Memory (req=limit) | CPU request |
|---|---|---|
| `run-opm-with-user-args` | 512Mi | 100m |
| `convert-image-tags-to-digests` | 64Mi | 250m |
| `replace-related-images-pullspec-in-file` | 64Mi | 50m |

`use-trusted-artifact` and `create-trusted-artifact` do not have `computeResources` set, following this repo's convention (other OCI-TA tasks here omit them as well).

## Sizing rationale

Fleet analysis run against 12 Konflux clusters over a 60-day window (6,470 pod executions across 5 clusters with data):

```bash
$ ./analyze_resource_limits.py \
    --file https://github.com/konflux-ci/konflux-operator-tasks/blob/main/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml \
    --analyze-again --margin 5 --days 60 --pll-clusters 4 --pll-queries 4
```

| Step | Fleet P95 Memory | P95+5% | PR Memory | Fleet P95 CPU | P95+5% | PR CPU |
|---|---|---|---|---|---|---|
| `run-opm-with-user-args` | 502 MB | 527 MB | 512Mi (~537 MB) ✅ | 75m | 79m | 100m ✅ |
| `convert-image-tags-to-digests` | 15 MB | 16 MB | 64Mi (~67 MB) ✅ | 239m | 251m | 250m ✅ |
| `replace-related-images-pullspec-in-file` | 7 MB | 7.4 MB | 64Mi (~67 MB) ✅ | 0m | 0m | 50m (floor) ✅ |

- No `cpu.limit` is set on any step (per policy), allowing burst above request.

## Risk Assessment

| Area | Risk | Mitigation |
|---|---|---|
| **OOM on `run-opm-with-user-args`** | Low — fleet max was 670 MB (single large FBC catalog), exceeding the 512Mi limit | Heavy tenants can [override compute resources](https://konflux.pages.redhat.com/docs/users/building/overriding-compute-resources.html) at pipeline level. P95+5% (527 MB) is covered by 512Mi (~537 MB). |
| **OOM on `convert-image-tags-to-digests`** | Very low — fleet P95 is 15 MB (max 17 MB), well within 64Mi | The step runs `jq` + `skopeo inspect --no-tags` (metadata only, no image pull). Memory footprint is small. If a future catalog grows significantly, the limit can be bumped. |
| **OOM on `replace-related-images-pullspec`** | Very low — fleet P95 is 7 MB (max 26 MB), well within 64Mi | Lightweight text-processing step. |
| **CPU throttling** | None — no `cpu.limit` set per policy | Pods can burst above `cpu.request`. |
| **Regression risk** | None — no functional code changes | Only `computeResources` blocks added; task logic is untouched. |
| **Rollback** | Trivial — revert the commit to remove `computeResources` | No dependencies on other changes. |

## Jira

KONFLUX-13055

Signed-off-by: Subrata Modak <smodak@redhat.com>