### PR TITLE
Update tasks references for fbc-inject-lifecycle

### DIFF
--- a/.tekton/fbc-inject-lifecycle-oci-ta-v01-pull-request.yaml
+++ b/.tekton/fbc-inject-lifecycle-oci-ta-v01-pull-request.yaml
@@ -112,7 +112,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.2@sha256:421003a5c077ecb820460e71637125ec9093d2101c749a32ede28e190283e9db
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
         - name: kind
           value: task
         resolver: bundles
@@ -133,7 +133,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e46c6578476caa8814ffd3322deeb9533c5b57396aedc758e554a663ba984eee
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
         - name: kind
           value: task
         resolver: bundles
@@ -159,7 +159,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
         - name: kind
           value: task
         resolver: bundles
@@ -187,7 +187,7 @@ spec:
         - name: name
           value: tkn-bundle-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:9e5dce0c4b1808ef68ea2b5b77a67936576f82e5b773b5f8a3b7a7b494ebd94d
+          value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:35ebaaa9ad1b44086f5d92805a5b2eaa8ff26cb9516b7212b64c6b0caf0b6440
         - name: kind
           value: task
         resolver: bundles
@@ -207,7 +207,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:0b4251ea0fab38be2b1441bea2788220d4cf2963ffb854a0ed90992fbabbe122
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:e1d79f08fb96babb606b2cd0a3f1dc9d9084c5e7206365d1e51e3dc1f923c949
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/fbc-inject-lifecycle-oci-ta-v01-push.yaml
+++ b/.tekton/fbc-inject-lifecycle-oci-ta-v01-push.yaml
@@ -109,7 +109,7 @@ spec:
         - name: name
           value: init
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4.2@sha256:421003a5c077ecb820460e71637125ec9093d2101c749a32ede28e190283e9db
+          value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
         - name: kind
           value: task
         resolver: bundles
@@ -130,7 +130,7 @@ spec:
         - name: name
           value: git-clone-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.2@sha256:e46c6578476caa8814ffd3322deeb9533c5b57396aedc758e554a663ba984eee
+          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
         - name: kind
           value: task
         resolver: bundles
@@ -156,7 +156,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
         - name: kind
           value: task
         resolver: bundles
@@ -184,7 +184,7 @@ spec:
         - name: name
           value: tkn-bundle-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:9e5dce0c4b1808ef68ea2b5b77a67936576f82e5b773b5f8a3b7a7b494ebd94d
+          value: quay.io/konflux-ci/tekton-catalog/task-tkn-bundle-oci-ta:0.2@sha256:35ebaaa9ad1b44086f5d92805a5b2eaa8ff26cb9516b7212b64c6b0caf0b6440
         - name: kind
           value: task
         resolver: bundles
@@ -204,7 +204,7 @@ spec:
         - name: name
           value: build-image-index
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:0b4251ea0fab38be2b1441bea2788220d4cf2963ffb854a0ed90992fbabbe122
+          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:e1d79f08fb96babb606b2cd0a3f1dc9d9084c5e7206365d1e51e3dc1f923c949
         - name: kind
           value: task
         resolver: bundles

--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -224,6 +224,8 @@ spec:
         declare -a ALLOWED_BASE_IMAGES=(
           "registry.redhat.io/openshift4/ose-operator-registry"
           "registry.redhat.io/openshift4/ose-operator-registry-rhel9"
+          "registry.redhat.io/openshift5/ose-operator-registry"
+          "registry.redhat.io/openshift5/ose-operator-registry-rhel9"
           "brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9"
         )
 


### PR DESCRIPTION
Release of fbc-inject-lifecycle task image failed dues to Conforma violation:
```
Results:
✕ [Violation] tasks.required_untrusted_task_found
  ImageRef: quay.io/redhat-user-workloads/rhtap-integration-tenant/fbc-inject-lifecycle-oci-ta-v01@sha256:3270361b075c1657e783ab2fd739b0f2a1c717eb071d35a6af5be79c5f21ab3f
  Reason: Required task "init" is required and present but not from a trusted task
  Term: init
  Title: All required tasks are from trusted tasks
  Description: Ensure that the all required tasks are resolved from trusted tasks. To exclude this rule add
  "tasks.required_untrusted_task_found:init" to the `exclude` section of the policy configuration.
  Solution: Make sure all required tasks in the build pipeline are resolved from trusted tasks.
  ```
  
  The PR that was created by Konflux had bundle digest (SHA) that is not on the "trusted tasks" list yet.
  I'm updating the other tasks as well to use trusted SHAs.


Release pipeline: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/konflux-operator-tasks/pipelineruns/managed-4dqtw?releaseName=konflux-operator-tasks-20260630-184828-000-40afd7a-mgh85


Also, added these 2 images to allowed base images in validate-fbc:
```
"registry.redhat.io/openshift5/ose-operator-registry"
"registry.redhat.io/openshift5/ose-operator-registry-rhel9"
```
Context: 
```
ose-operator-registry-rhel9:v5.0 is currently shipped to both:

[registry.redhat.io/openshift4/ose-operator-registry-rhel9:v5.0]

[registry.redhat.io/openshift5/ose-operator-registry-rhel9:v5.0]

The openshift4 release happened because the openshift5 namespace hadn't been created yet when the image was needed for bootstrapping.

Going forward, we want the v5.0 image to be maintained and updated only in `openshift5`, with a single canonical entry for v5.0 living there.
```
