### PR TITLE
CLOUDDST-32593: Bump validate-fbc and add migration script

### DIFF
--- a/task/validate-fbc/0.2/MIGRATION.md
+++ b/task/validate-fbc/0.2/MIGRATION.md
@@ -1,0 +1,26 @@
+# Migration from 0.1 to 0.2
+
+## What Changed
+
+No functional changes were made to `validate-fbc` itself. This version bump
+is used to automatically inject the new `fbc-inject-lifecycle-oci-ta` task
+into FBC builder pipelines via MintMaker.
+
+## What the Migration Script Does
+
+MintMaker will open a PR that automatically:
+
+1. Adds the `fbc-inject-lifecycle` task after the clone task.
+2. Rewires `SOURCE_ARTIFACT` so downstream tasks consume the output of
+   `fbc-inject-lifecycle` instead of the clone task directly.
+3. Updates `runAfter` dependencies for affected downstream tasks.
+
+The task is safe for all FBC pipelines — it skips injection at runtime for
+components not targeting OCP 5.0+.
+
+## Action from Users
+
+No action required. Review and merge the MintMaker PR once CI passes.
+
+If the migration script fails, manually add `fbc-inject-lifecycle` following the
+standard FBC pipeline blueprint in `build-definitions`.

--- a/task/validate-fbc/0.2/README.md
+++ b/task/validate-fbc/0.2/README.md
@@ -1,0 +1,22 @@
+# validate-fbc task
+
+Ensures file-based catalog (FBC) components are uniquely linted for proper construction as part of build pipeline. The manifest data of container images is checked using OpenShift Operator Framework's opm CLI tool. The opm binary is extracted from the container's base image, which must come from a trusted source.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE_URL|Fully qualified image name.||true|
+|IMAGE_DIGEST|Image digest.||true|
+
+## Results
+|name|description|
+|---|---|
+|RELATED_IMAGE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the related images for the FBC fragment.|
+|TEST_OUTPUT_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the related images for the FBC fragment.|
+|TEST_OUTPUT|Tekton task test output.|
+|RELATED_IMAGES_DIGEST|Digest for attached json file containing related images|
+|IMAGES_PROCESSED|Images processed in the task.|
+|RENDERED_CATALOG_DIGEST|Digest for attached json file containing the FBC fragment's opm rendered catalog.|
+
+
+## Additional info

--- a/task/validate-fbc/0.2/TROUBLESHOOTING.md
+++ b/task/validate-fbc/0.2/TROUBLESHOOTING.md
@@ -1,0 +1,21 @@
+
+## Bundle properties are not permitted in a FBC fragment for OCP version
+
+Tasks may fail with an error message containing the string `bundle properties are not permitted in a FBC fragment for OCP version`.  This means that your fragment needs to utilize the appropriate FBC bundle metadata format which aligns with your target catalog. Failure to do so will result in your package not being displayed in the OpenShift Console.
+
+For OCP versions:
+- _4.16 or earlier_, bundle metadata must use the `olm.bundle.object` format
+- _4.17 or later_, bundle metadata must use the `olm.csv.metadata` format
+
+### If you use `opm` tooling to generate your fragment
+
+Note: This assumes that opm is version v1.46.0 or later.
+
+If you generate your FBC using catalog template expansion or migration of existing catalogs, then by default, the tool will output `olm.bundle.object` metadata format.
+You can choose to produce `olm.csv.metadata` format by using the `--migrate-level=bundle-object-to-csv-metadata` flag.  
+
+### If you use other tooling to generate your fragment
+
+Bundle data in `olm.csv.metadata` format contains only information that the OpenShift Console needs which is derived from the package's Cluster Standard Version(CSV).  Since the previous `olm.bundle.object` format would include bundle CSV metadata as well as other properties it is possible to convert from `olm.bundle.object` to `olm.csv.metadata`, but not the reverse. 
+
+If you rely on other tooling/processes to produce your fragment and currently use the `olm.bundle.object` bundle metadata format, then you may either adjust your tooling to generate `olm.csv.metadata` format or you may use `opm` to migrate your fragment's bundle metadata by using `opm render --migrate-level=bundle-object-to-csv-metadata [fragment-ref]` (where `fragment-ref` is a pullspec to the fragment or a path to a directory containing the fragment).

--- a/task/validate-fbc/0.2/USAGE.md
+++ b/task/validate-fbc/0.2/USAGE.md
@@ -1,0 +1,44 @@
+# validate-fbc task
+
+## Checks
+### Valid base image
+To validate the image in build pipeline, Skopeo is used to extract
+information from the image itself and then contents are checked using the OpenShift Operator Framework.  The binary
+used to run the validation is extracted from the base image for the component being tested.  Because of this, the
+base image must come from a trusted source.  Trusted sources are declared in `ALLOWED_BASE_IMAGES` in fbc-validation.yaml.
+
+### Valid FBC schema
+To validate the schema format of the FBC fragment, the test
+1. validates that the `operators.operatoframework.io.index.configs.v1` label is present on the image to identify the fragment path
+2. extracts the `opm` binary from the base image for the fragment
+3. executes `opm validate` over the fragment
+
+### At least one package in fragment
+To validate that at least one package is included in the fragment, the test renders the FBC using `opm` and uses `jq` to count instances of `olm.package` and fails if there are none.
+
+### Valid Directory Structure
+To ensure compatibility with downstream service IIB, the task validates the directory structure within the FBC fragment. The validation enforces the following rules:
+
+- The conffolder folder must contain one or more subdirectories, where each subdirectory represents an operator package.
+- Each operator package subdirectory must contain a catalog file named catalog.json, catalog.yaml, or catalog.yml.
+
+An example of a valid structure:
+```bash
+/configs
+├── my-operator-a/
+│   └── catalog.json
+└── my-operator-b/
+    └── catalog.yaml
+```
+
+### Bundle metadata in the appropriate format
+To validate bundle metadata, the test evaluates bundle metadata usage against the target OCP version:
+- for 4.16 and earlier, fragments must use `olm.bundle.object` (and not use `olm.csv.metadata`)
+- for 4.17 and later, fragments must use `olm.csv.metadata` (and not use `olm.bundle.object`)
+
+## Data output
+### Related images
+
+OPM will be used to render the catalog in order to identify the set of related images for the fragment.
+These images will then be saved as an output artifact so that EC can verify that the pullspecs are valid
+before releasing the fragment.

--- a/task/validate-fbc/0.2/migrations/0.2.sh
+++ b/task/validate-fbc/0.2/migrations/0.2.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# Only apply to FBC pipelines - identified by presence of validate-fbc task,
+# which is required in all FBC builder pipelines.
+if ! grep -q "validate-fbc" "$pipeline_file"; then
+  exit 0
+fi
+
+# Determine the tasks path based on the resource kind.
+# - Pipeline: tasks live at .spec.tasks
+# - PipelineRun: tasks live at .spec.pipelineSpec.tasks (embedded spec)
+kind=$(yq -e '.kind' "$pipeline_file")
+if [[ "$kind" == "PipelineRun" ]]; then
+  tasks_selector=".spec.pipelineSpec.tasks[]"
+elif [[ "$kind" == "Pipeline" ]]; then
+  tasks_selector=".spec.tasks[]"
+else
+  echo "Unknown kind '$kind' in $pipeline_file, skipping"
+  exit 0
+fi
+
+# Skip if already added (idempotent).
+# Uses yq to check for an actual task object rather than grep, which would
+# false-positive on SOURCE_ARTIFACT references or bundle_ref strings.
+if yq -e "${tasks_selector} | select(.name == \"fbc-inject-lifecycle\")" "$pipeline_file" >/dev/null 2>&1; then
+  exit 0
+fi
+
+bundle_ref="quay.io/konflux-ci/tekton-catalog/task-fbc-inject-lifecycle-oci-ta:0.1@sha256:9b6d61e5e887a8f30940c1fed0e118b8974c382d0a6328db99705a44365f6b0b"
+clone_task_name=""
+
+for task_refname in "git-clone-oci-ta" "git-clone-oci-ta-min"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[]? | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null 2>&1; then
+        clone_task_name="$(yq -e "${task_selector} | .name" "${pipeline_file}" | head -1)"
+        break
+    fi
+done
+
+if [[ -z "$clone_task_name" ]]; then
+    echo "No git-clone-oci-ta task found in $pipeline_file, skipping"
+    exit 0
+fi
+
+# Step 1: Rewire SOURCE_ARTIFACT param references from the clone task to fbc-inject-lifecycle.
+# This runs BEFORE pmt add-task so that fbc-inject-lifecycle's own param is inserted
+# after the sed pass and remains untouched.
+sed -i "s/\$(tasks\.${clone_task_name}\.results\.SOURCE_ARTIFACT)/\$(tasks.fbc-inject-lifecycle.results.SOURCE_ARTIFACT)/g" \
+  "$pipeline_file"
+
+# Step 2: Inject fbc-inject-lifecycle after the clone task.
+# Because this runs after Step 1, its own SOURCE_ARTIFACT param referencing the clone task
+# is inserted fresh and will not be overwritten by sed.
+# shellcheck disable=SC2016  # Tekton $(params.*) expressions must not be expanded by Bash
+pmt add-task "$bundle_ref" \
+  "$pipeline_file" \
+  --run-after "$clone_task_name" \
+  --pipeline-task-name "fbc-inject-lifecycle" \
+  --param 'DOCKERFILE=$(params.dockerfile)' \
+  --param 'CONTEXT=$(params.path-context)' \
+  --param "SOURCE_ARTIFACT=\$(tasks.${clone_task_name}.results.SOURCE_ARTIFACT)" \
+  --param 'ociStorage=$(params.output-image).lifecycle' \
+  --param 'ociArtifactExpiresAfter=$(params.image-expires-after)'
+
+# Step 2a: Fix taskRef bundle name — pmt doesn't strip the 'task-' prefix when
+# deriving the pipeline task name from the OCI repo name.
+yq -i "
+  (${tasks_selector} |
+   select(.name == \"fbc-inject-lifecycle\") |
+   .taskRef.params[] |
+   select(.name == \"name\")).value = \"fbc-inject-lifecycle-oci-ta\"
+" "$pipeline_file"
+
+# Step 3: Update runAfter ONLY for tasks that consume SOURCE_ARTIFACT from fbc-inject-lifecycle
+# (i.e. tasks that were rewired in Step 1). This intentionally excludes tasks like build-images
+# whose runAfter: [clone-repository] is redundant — they are implicitly ordered via their
+# prefetch-dependencies param references and do not need updating.
+yq -i "
+  (${tasks_selector} |
+   select(.name != \"fbc-inject-lifecycle\") |
+   select(.params[]?.value == \"\$(tasks.fbc-inject-lifecycle.results.SOURCE_ARTIFACT)\") |
+   .runAfter[]? |
+   select(. == \"${clone_task_name}\")) = \"fbc-inject-lifecycle\"
+" "$pipeline_file"
+
+echo "Successfully injected fbc-inject-lifecycle after $clone_task_name in $pipeline_file"

--- a/task/validate-fbc/0.2/validate-fbc.yaml
+++ b/task/validate-fbc/0.2/validate-fbc.yaml
@@ -1,0 +1,549 @@
+# TODO:
+#   change the related-image check to be done in EC with exported related images instead of
+#     including it in the TEST_OUTPUT result
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: validate-fbc
+spec:
+  description: >-
+    Ensures file-based catalog (FBC) components are uniquely linted for proper construction as part of build pipeline.
+    The manifest data of container images is checked using OpenShift Operator Framework's opm CLI tool.
+    The opm binary is extracted from the container's base image, which must come from a trusted source.
+  params:
+    - name: IMAGE_URL
+      description: Fully qualified image name.
+      type: string
+    - name: IMAGE_DIGEST
+      description: Image digest.
+      type: string
+  results:
+    - name: RELATED_IMAGE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the related images for the FBC fragment.
+    - name: TEST_OUTPUT_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the related images for the FBC fragment.
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+    - name: RELATED_IMAGES_DIGEST
+      description: Digest for attached json file containing related images
+    - name: IMAGES_PROCESSED
+      description: Images processed in the task.
+    - name: RENDERED_CATALOG_DIGEST
+      description: Digest for attached json file containing the FBC fragment's opm rendered catalog.
+  volumes:
+    - name: shared
+      emptyDir: {}
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    env:
+      - name: IMAGE_URL
+        value: $(params.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(params.IMAGE_DIGEST)
+      - name: IMAGE_INSPECT
+        value: /shared/image_inspect.json
+      - name: BASE_IMAGE_INSPECT
+        value: /shared/base_image_inspect.json
+      - name: RAW_IMAGE_INSPECT
+        value: /shared/raw_image_inspect.json
+      - name: OPM_RENDER_CACHE
+        value: /shared/render-cache/
+    volumeMounts:
+      - mountPath: /shared
+        name: shared
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: inspect-image
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      workingDir: /var/workdir/inspect-image
+      securityContext:
+        runAsUser: 0
+        capabilities:
+          add:
+            - SETFCAP
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        # shellcheck source=/dev/null
+        source /utils.sh
+        trap 'handle_error "$(results.TEST_OUTPUT.path)"' EXIT
+
+        # Given a tag and a the digest in the IMAGE_URL we opt to use the digest alone
+        # this is because containers/image currently doesn't support image references
+        # that contain both. See https://github.com/containers/image/issues/1736
+        IMAGE_URL="$(get_image_registry_and_repository "${IMAGE_URL}")"
+        image_with_digest="$(get_image_registry_repository_digest "${IMAGE_URL}@${IMAGE_DIGEST}")"
+
+        status=0
+        manifest_digests="$(get_image_manifests -i "$image_with_digest")" || status=$?
+        if [ "$status" -ne 0 ]; then
+            echo "Failed to get manifests for ${image_with_digest}"
+            note="Step inspect-image failed: Encountered errors while inspecting image. For details, check Tekton task log."
+            TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 0
+        fi
+        echo "Manifest digests are: ${manifest_digests}"
+
+        # Use the amd64 manifest digest for future operations
+        reference_manifest_digest=$(echo -n "${manifest_digests}" | jq -jr '.amd64')
+        if [[ "${reference_manifest_digest}" == "null" ]]; then
+            echo "No amd64 image manifest found for ${image_with_digest}"
+            note="Step inspect-image failed: Encountered errors while inspecting image. For details, check Tekton task log."
+            TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 0
+        fi
+        image_with_digest="$(get_image_registry_repository_digest "${IMAGE_URL}@${reference_manifest_digest}")"
+        echo -n "${image_with_digest}" > /shared/image_with_digest
+
+        # FBC content should be identical across different architectures so the IMAGES_PROCESSED result
+        # is a no-op for now. We can come back later and enforce that the content is identical between
+        # all architectures if desired.
+        images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
+        if [ -n "$manifest_digests" ]; then
+          while read -r _arch arch_sha; do
+            digests_processed+=("\"$arch_sha\"")
+          done < <(echo "$manifest_digests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+        fi
+
+        # If the image is an Image Index, also add the Image Index digest to the list.
+        if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
+          digests_processed+=("\"$IMAGE_DIGEST\"")
+        fi
+        digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
+        echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee "$(results.IMAGES_PROCESSED.path)"
+
+        skopeo_retries=3
+
+        echo "Inspecting manifest for source image ${image_with_digest}."
+        if ! retry skopeo inspect --retry-times "$skopeo_retries" --no-tags docker://"${image_with_digest}" > "$IMAGE_INSPECT"
+        then
+          echo "Failed to inspect image ${image_with_digest}"
+          note="Step inspect-image failed: Encountered errors while inspecting image. For details, check Tekton task log."
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+        echo "Image ${image_with_digest} metadata:"
+        cat "$IMAGE_INSPECT"
+
+        echo "Inspecting manifest for source image ${image_with_digest}."
+        if ! retry skopeo inspect --retry-times "$skopeo_retries" --no-tags --raw docker://"${image_with_digest}" > "$RAW_IMAGE_INSPECT"
+        then
+          echo "Failed to get raw metadata of image ${image_with_digest}"
+          note="Step inspect-image failed: Encountered errors while inspecting image. For details, check Tekton task log."
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        echo "Image ${image_with_digest} raw metadata:"
+        jq < "$RAW_IMAGE_INSPECT" # jq for readable formatting
+
+        echo "Getting base image manifest for source image ${image_with_digest}."
+        if ! get_base_image "${image_with_digest}" > /shared/base_image
+        then
+          echo "Unable to find base image for ${image_with_digest}."
+          note="Step inspect-image failed: Cannot find base image. For details, check Tekton task log."
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        echo "Detected base image:"
+        cat /shared/base_image
+        echo -e "\nDetected base image repository:"
+        get_image_registry_and_repository "$(cat /shared/base_image)" | tee /shared/base_image_repository
+        echo -e "\nDetected base image:"
+        echo "get_image_registry_repository_digest $(cat /shared/base_image)"
+        get_image_registry_repository_digest "$(cat /shared/base_image)" | tee /shared/base_image_with_digest
+        echo "" # the above has no newline
+        base_image_with_digest=$(cat /shared/base_image_with_digest)
+
+        echo "Inspecting base image ${base_image_with_digest}."
+        if ! retry skopeo inspect --retry-times "$skopeo_retries" --no-tags "docker://$base_image_with_digest"  > "$BASE_IMAGE_INSPECT"
+        then
+          echo "Failed to inspect base image ${base_image_with_digest}"
+          note="Step inspect-image failed: Encountered errors while inspecting image. For details, check Tekton task log."
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+    - name: extract-and-validate
+      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      workingDir: /var/workdir/extract-and-validate
+      securityContext:
+        runAsUser: 0
+        capabilities:
+          add:
+            - SETFCAP
+      computeResources:
+        limits:
+          memory: 10Gi
+        requests:
+          memory: 10Gi
+          cpu: "8"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ -s $(results.TEST_OUTPUT.path) ]]; then
+          echo "Test failed in previous step. Bailing."
+          echo "For details, check Tekton task result TEST_OUTPUT in the inspect-image step."
+          exit 0
+        fi
+
+        source /utils.sh
+        trap 'handle_error "$(results.TEST_OUTPUT.path)"' EXIT
+
+        image_with_digest=$(cat /shared/image_with_digest)
+        base_image_with_digest=$(cat /shared/base_image_with_digest)
+        base_image_repository=$(cat /shared/base_image_repository)
+        note=""
+
+        declare -a ALLOWED_BASE_IMAGES=(
+          "registry.redhat.io/openshift4/ose-operator-registry"
+          "registry.redhat.io/openshift4/ose-operator-registry-rhel9"
+          "registry.redhat.io/openshift5/ose-operator-registry"
+          "registry.redhat.io/openshift5/ose-operator-registry-rhel9"
+          "brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9"
+        )
+
+        ### FBC base image check
+        allowed=false
+        for value in "${ALLOWED_BASE_IMAGES[@]}"
+        do
+          if [[ "${base_image_repository}" == "${value}" ]]; then
+            allowed=true
+            break
+          fi
+        done
+
+        if [[ "${allowed}" == false ]]; then
+          echo "Base image ${base_image_with_digest} is not allowed for the file based catalog image. Allowed images: " "${ALLOWED_BASE_IMAGES[@]}"
+          note="Step extract-and-validate failed: Base image ${base_image_with_digest} is not allowed for the file based catalog image. For details, check Tekton task logs."
+          TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        status=0
+        OCP_VER_FROM_BASE=$(get_ocp_version_from_fbc_fragment "$image_with_digest") || status=$?
+        if [ $status -ne 0 ]; then
+          echo "!FAILURE! - Could not get OCP version. See https://konflux-ci.dev/architecture/ADR/0026-specifying-ocp-targets-for-fbc.html for defining the parent image."
+          note="Step extract-and-validate failed: Could not get the OCP version from the base.  For details, check Tekton task logs."
+          TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        ### Try to extract binaries with configs > check binaries functionality > check opm validate ###
+        if [ ! -s "$IMAGE_INSPECT" ]; then
+          echo "File $IMAGE_INSPECT did not generate correctly. Check inspect-image task log."
+          note="Step extract-and-validate failed: $IMAGE_INSPECT did not generate correctly. For details, check Tekton task result TEST_OUTPUT in task inspect-image."
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        if [ ! -s "$RAW_IMAGE_INSPECT" ]; then
+          echo "File $RAW_IMAGE_INSPECT did not generate correctly. Check inspect-image task log."
+          note="Step extract-and-validate failed: $RAW_IMAGE_INSPECT did not generate correctly. For details, check Tekton task result TEST_OUTPUT in task inspect-image."
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        status=0
+        conffolder=$(jq -r '.Labels ."operators.operatorframework.io.index.configs.v1"' "$IMAGE_INSPECT") || status=$?
+        if [[ $status -ne 0 ||  "${conffolder}" == "null" ]]; then
+          echo "Could not get 'operators.operatorframework.io.index.configs.v1' label from ${IMAGE_INSPECT}. Make sure file exists and it contains this label."
+          TEST_OUTPUT="$(make_result_json -r ERROR)"
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+        mkdir -p /tmp/image-content confdir
+        pushd /tmp/image-content
+
+        if ! retry oc image extract --registry-config ~/.docker/config.json "${image_with_digest}" ; then
+          echo "Unable to extract or validate extracted binaries."
+          note="Step extract-and-validate failed: Failed to extract image with oc extract command, so it cannot validate extracted binaries. For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          popd
+          exit 0
+        fi
+
+        if [ -z "$(ls -A .$conffolder)" ]; then
+          echo "$conffolder is missing catalog file."
+          TEST_OUTPUT="$(make_result_json -r ERROR)"
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          popd
+          exit 0
+        fi
+
+        EXTRACT_DIR="/extracted_base_img"
+        mkdir "${EXTRACT_DIR}"
+        if ! retry oc image extract "${base_image_with_digest}" --path /:"${EXTRACT_DIR}"; then
+          echo "Unable to extract opm binary"
+          note="Step extract-and-validate failed: Failed to extract base image with oc extract command, so it cannot validate extracted binaries.  For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        # extract the opm binary for operations
+        OPM_BINARIES="$(find "${EXTRACT_DIR}" -type f -name opm)"
+        BINARIES_COUNT=$(wc -l <<< "${OPM_BINARIES}")
+        if [[ $BINARIES_COUNT -ne "1" ]]; then
+            note="Step extract-and-validate failed: Expected exactly one opm binary in base image.  For details, check Tekton task log"
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            echo "found $BINARIES_COUNT opm binaries:"
+            echo "${OPM_BINARIES}"
+            exit 0
+        fi
+        OPM_BINARY=$(echo "${OPM_BINARIES}" | head -n 1)
+        echo "OPM_BINARY: '${OPM_BINARY}'"
+        chmod 775 "$OPM_BINARY"
+
+        # Insert the binary location to the beginning of the path
+        # so that the same binary version is used for all functions
+        mkdir -p /shared/bin/
+        mv "$OPM_BINARY" /shared/bin/opm
+        export PATH=/shared/bin:$PATH
+
+        # We have 10 total checks
+        check_num=10
+        failure_num=0
+        TESTPASSED=true
+
+        if [[ ! $(find . -name "grpc_health_probe") ]]; then
+          echo "!FAILURE! - grpc_health_probe binary presence check failed."
+          failure_num=$((failure_num + 1))
+          TESTPASSED=false
+        fi
+
+        ### FBC DIRECTORY STRUCTURE VALIDATION ###
+        echo "Validating FBC directory structure."
+        PACKAGE_DIRS=$(find ".${conffolder}" -mindepth 1 -maxdepth 1 -type d)
+
+        # First, check if any package subdirectories exist at all.
+        if [[ -z "${PACKAGE_DIRS}" ]]; then
+          echo "!FAILURE! - No package subdirectories found inside '.${conffolder}'. At least one is required."
+          echo "--> The FBC image must contain one or more package directories."
+          echo "    Example valid structure:"
+          echo "    ${conffolder}/"
+          echo "    └── <package-name>/"
+
+          # Set the note for the final error report
+          note="FBC directory structure validation failed: No package subdirectories were found inside the '${conffolder}' directory."
+
+          failure_num=$((failure_num + 1))
+          TESTPASSED=false
+        else
+          # Array to hold directories that are found to be empty
+          empty_dirs=()
+
+          # Loop through each found package directory to check if it's empty
+          while IFS= read -r pkg_dir; do
+            # Check if the find command returns anything inside the directory
+            if [[ -z "$(find "${pkg_dir}" -mindepth 1)" ]]; then
+              echo "!FAILURE! - Package directory '${pkg_dir}' is empty."
+              empty_dirs+=("${pkg_dir}")
+            fi
+          done <<< "${PACKAGE_DIRS}"
+
+          # After checking all directories, report if any were empty
+          if [[ ${#empty_dirs[@]} -gt 0 ]]; then
+            echo "--> FBC package directories must not be empty."
+            echo "    Example valid structure:"
+            echo "    ${conffolder}/"
+            echo "    └── <package-name>/"
+
+            # Set a detailed note for the final error report, listing all empty directories
+            note="FBC directory validation failed. The following package directories are empty: ${empty_dirs[*]}"
+
+            failure_num=$((failure_num + 1))
+            TESTPASSED=false
+          else
+            echo "FBC directory structure is valid."
+          fi
+        fi
+
+        if ! opm validate ."${conffolder}"; then
+          echo "!FAILURE! - opm validate check failed."
+          failure_num=$((failure_num + 1))
+          TESTPASSED=false
+        fi
+
+        echo "Rendering catalog fragment."
+        OPM_RENDERED_CATALOG=/shared/catalog.json
+        render_opm -t ."${conffolder}" > ${OPM_RENDERED_CATALOG}
+        if [ ! -f ${OPM_RENDERED_CATALOG} ]; then
+          echo "!FAILURE! - unable to render the fragment FBC."
+          failure_num=$((failure_num + 1))
+          TESTPASSED=false
+        fi
+
+        if jq -en 'reduce (inputs | select(.schema == "olm.package")) as $obj (0; .+1) < 1' ${OPM_RENDERED_CATALOG}; then
+          echo "!FAILURE! - There are no olm package entries defined in this FBC fragment."
+          failure_num=$((failure_num + 1))
+          TESTPASSED=false
+        fi
+
+        # examines the base image tag to derive the target OCP version
+        # assumes this is in the form
+        # image-path:[v]major-digits.minor-digits[@sha...]
+        # extracts major digits and filters out any leading alphabetic characters, for e.g. 'v4' --> '4'
+        OCP_VER_MAJOR=$(echo "${OCP_VER_FROM_BASE}" | cut -d '.' -f 1 | sed "s/^[a-zA-Z]*//")
+        OCP_VER_MINOR=$(echo "${OCP_VER_FROM_BASE}" | cut -d '.' -f 2)
+
+        RUN_OCP_VERSION_VALIDATION="false"
+        digits_regex='^[0-9]*$'
+        if [[ ${OCP_VER_MAJOR} =~ $digits_regex ]] && [[ ${OCP_VER_MINOR} =~ $digits_regex ]] ; then
+          RUN_OCP_VERSION_VALIDATION="true"
+        fi
+
+        if [ "${RUN_OCP_VERSION_VALIDATION}" == "false" ] ; then
+          echo "!WARNING! - unable to assess bundle metadata alignment with OCP version because we cannot parse OCP version from the base image ${OCP_VER_FROM_BASE}"
+        else
+          OCP_BUNDLE_METADATA_THRESHOLD_MAJOR=4
+          OCP_BUNDLE_METADATA_THRESHOLD_MINOR=17
+          OCP_BUNDLE_METADATA_FORMAT="olm.bundle.object"
+
+          if [[ "${OCP_VER_MAJOR}" -gt "${OCP_BUNDLE_METADATA_THRESHOLD_MAJOR}" ]] || [[ "${OCP_VER_MAJOR}" -eq "${OCP_BUNDLE_METADATA_THRESHOLD_MAJOR}" && "${OCP_VER_MINOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MINOR}" ]]; then
+             OCP_BUNDLE_METADATA_FORMAT="olm.csv.metadata"
+          fi
+
+          # enforce the presence of either olm.csv.metadata or olm.bundle.object based on OCP version
+          if [[ "${OCP_BUNDLE_METADATA_FORMAT}" = "olm.csv.metadata" ]]; then
+            if ! jq -en 'reduce( inputs | select(.schema == "olm.bundle" and .properties[].type == "olm.bundle.object")) as $_ (0;.+1) == 0' ${OPM_RENDERED_CATALOG}; then
+              echo "!FAILURE! - olm.bundle.object bundle properties are not permitted in a FBC fragment for OCP version ${OCP_VER_MAJOR}.${OCP_VER_MINOR}. Fragments must move to olm.csv.metadata bundle metadata."
+              failure_num=$((failure_num + 1))
+              TESTPASSED=false
+            fi
+          else
+            if ! jq -en 'reduce( inputs | select(.schema == "olm.bundle" and .properties[].type == "olm.csv.metadata")) as $_ (0;.+1) == 0' ${OPM_RENDERED_CATALOG}; then
+              echo "!FAILURE! - olm.csv.metadata bundle properties are not permitted in a FBC fragment for OCP version ${OCP_VER_MAJOR}.${OCP_VER_MINOR}. Fragments must only use olm.bundle.object bundle metadata."
+              failure_num=$((failure_num + 1))
+              TESTPASSED=false
+            fi
+          fi
+
+          # enforce that each bundle has the OCP-version-appropriate bundle metadata.
+          BUNDLE_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema=="olm.bundle"))' ${OPM_RENDERED_CATALOG})
+          BUNDLE_BO_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema == "olm.bundle" and .properties[].type == "olm.bundle.object"))' ${OPM_RENDERED_CATALOG})
+          BUNDLE_CM_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema == "olm.bundle" and .properties[].type == "olm.csv.metadata"))' ${OPM_RENDERED_CATALOG})
+
+          if [[ "${OCP_BUNDLE_METADATA_FORMAT}" = "olm.csv.metadata" ]]; then
+            if [[ "${BUNDLE_COUNT}" -ne "${BUNDLE_CM_COUNT}" ]]; then
+              echo "!FAILURE! - every olm.bundle object in the fragment must have a corresponding olm.csv.metadata bundle property"
+            failure_num=$((failure_num + 1))
+              TESTPASSED=false
+            fi
+          else
+            if [[ "${BUNDLE_BO_COUNT}" -lt "${BUNDLE_COUNT}" ]]; then
+              echo "!FAILURE! - every olm.bundle object in the fragment must have at least one olm.bundle.object bundle property"
+            failure_num=$((failure_num + 1))
+              TESTPASSED=false
+            fi
+          fi
+        fi
+
+        # Get the new related images that are being added so that we can check them for validity
+        echo "Rendering target index and finding unreleased related images."
+        status=0
+        echo "Running command: get_unreleased_fbc_related_images -i ${image_with_digest}"
+        related_images=$(get_unreleased_fbc_related_images -i "$image_with_digest") || status=$?
+        if [ $status -ne 0 ]; then
+          get_unreleased_fbc_related_images -i "$image_with_digest"
+          echo "!FAILURE! - Could not get related images."
+          note="Step extract-and-validate failed ($status): Could not fetch related images. Make sure you have catalog.yaml or catalog.json formatted correctly in your file-based catalog (FBC) fragment image."
+          failure_num=$((failure_num + 1))
+          TESTPASSED=false
+        else
+          echo -n "$related_images" > /shared/related-images.json
+
+          # We have moved verification of the related images to a Conformal policy. This enables
+          # the results of this task to be stable in time (i.e. it doesn't need to be re-run after
+          # any other images have been released).
+          echo -e "Related images detected:\n$(jq -cr '.[]' /shared/related-images.json )."
+        fi
+
+        if [ $TESTPASSED == false ]; then
+          if [ -z "$note" ]; then
+            note="Step extract-and-validate failed: Validation checks failed. For details, check Tekton task log."
+          fi
+          ERROR_OUTPUT=$(make_result_json -r FAILURE -f $failure_num -s $((check_num - failure_num)) -t "$note")
+          echo -n "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        else
+          note="Task validate-fbc completed: Check result for task result."
+          TEST_OUTPUT=$(make_result_json -r SUCCESS -s $check_num -t "$note")
+          echo -n "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        fi
+        popd
+    - name: save-related-images
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      image: quay.io/konflux-ci/oras:latest@sha256:76d221b871642154f32151797186430a9cb8b46a194221870c2a87b1a0b916ff
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [ ! -f /shared/related-images.json ]; then
+          echo "Related images not generated. Skipping attach."
+          exit 0
+        fi
+        if ! retry attach-helper --subject "${IMAGE_URL}@${IMAGE_DIGEST}" --media-type-name "related-images+json" \
+          --digestfile "$(results.RELATED_IMAGES_DIGEST.path)" \
+          /shared/related-images.json
+        then
+          echo "Failed to attach related images to ${IMAGE_URL}@${IMAGE_DIGEST}"
+          exit 1
+        fi
+    - name: save-rendered-catalog
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      image: quay.io/konflux-ci/oras:latest@sha256:76d221b871642154f32151797186430a9cb8b46a194221870c2a87b1a0b916ff
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [ ! -f /shared/catalog.json ]; then
+          echo "Catalog not generated. Skipping attach."
+          exit 0
+        fi
+        if ! retry attach-helper --subject "${IMAGE_URL}@${IMAGE_DIGEST}" --media-type-name "rendered-catalog+json" \
+          --digestfile "$(results.RENDERED_CATALOG_DIGEST.path)" \
+          /shared/catalog.json
+        then
+          echo "Failed to attach catalog to ${IMAGE_URL}@${IMAGE_DIGEST}"
+          exit 1
+        fi

--- a/task/validate-fbc/CHANGELOG.md
+++ b/task/validate-fbc/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.2
+
+### Changed
+
+- Version bump to trigger automated rollout of the new `fbc-inject-lifecycle-oci-ta`
+  task to all FBC builder pipelines via MintMaker. No functional changes to this task.


### PR DESCRIPTION
## Summary

Bumps `validate-fbc` from `0.1` to `0.2` and adds a migration script that
MintMaker will execute across all FBC builder pipelines.

## Changes

- `validate-fbc` task: only change is `app.kubernetes.io/version: "0.2"` —
  no functional changes
- `README.md`, `TROUBLESHOOTING.md`, `USAGE.md`: copied from `0.1` unchanged
- `MIGRATION.md`: documents the migration
- `0.2.sh`: new migration script (see below)

## Migration Script

When MintMaker picks up the `validate-fbc` `0.1` → `0.2` bump, it will
execute `0.2.sh` against all affected pipelines. The script:

1. Adds the `fbc-inject-lifecycle-oci-ta` task after the clone task
2. Rewires `SOURCE_ARTIFACT` so downstream tasks consume the output of
   `fbc-inject-lifecycle` instead of the clone task directly
3. Updates `runAfter` dependencies for affected downstream tasks

Supports both `kind: Pipeline` and `kind: PipelineRun` files.

The task is only strictly required for OCP 5.0+ components — it will be
added to all FBC pipelines but is a no-op at runtime for components
targeting earlier OCP versions (the task's eligibility check handles this).

## Testing

Testing: https://docs.google.com/document/d/1k8SE9ujCn-ig2B2SwnQLNk4q7IiqH5ZlQ_NA_It6XA8/edit?usp=sharing