### PR TITLE
Add allowed_remote_resources to fullsend

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -16,3 +16,6 @@ create_issues:
         repos:
             - konflux-ci/konflux-operator-tasks
             - fullsend-ai/fullsend
+allowed_remote_resources:
+    - https://raw.githubusercontent.com/fullsend-ai/fullsend/
+    - https://raw.githubusercontent.com/fullsend-ai/agents/


### PR DESCRIPTION
We had to do the same for fbc-update-planner repo. This PR fized the issue: https://github.com/release-engineering/fbc-update-planner/pull/33
