### PR TITLE
fix(fbc-inject-lifecycle): pass CONTEXT to check-lifecycle-eligibility step

### DIFF
--- a/task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
+++ b/task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
@@ -92,12 +92,15 @@ spec:
       env:
         - name: DOCKERFILE
           value: $(params.DOCKERFILE)
+        - name: CONTEXT
+          value: $(params.CONTEXT)
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
 
         operator-foundry fbc check-lifecycle-eligibility \
           --dockerfile "${DOCKERFILE}" \
+          --build-context "${CONTEXT}" \
           --output /shared/eligible
 
         echo "[INFO] Component eligible for lifecycle injection (targets OCP 5.0+): $(cat /shared/eligible)"


### PR DESCRIPTION
Cannot be merged until https://github.com/konflux-ci/operator-foundry/pull/30 is merged and we have an image with the new parameter.
Context of the MR is there.