### PR TITLE
CLOUDDST-32714: Add workspace-source variant of fbc-inject-lifecycle

### DIFF
--- a/task/fbc-inject-lifecycle/0.1/README.md
+++ b/task/fbc-inject-lifecycle/0.1/README.md
@@ -1,0 +1,57 @@
+# fbc-inject-lifecycle task
+
+The fbc-inject-lifecycle task injects lifecycle data into a file-based catalog (FBC) component targeting OCP 5.0+. It determines the target OLM packages from the Dockerfile, generates lifecycle JSON files using `plcc2fbc`, and injects them into the catalog source directories.
+
+Lifecycle injection is skipped (with a successful result) if not all targeted OCP versions are >= 5.0.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings) used to resolve ARG references in the Dockerfile (e.g. in the base image tag or in COPY/ADD source paths).|[]|false|
+|caTrustConfigMapName|The name of the ConfigMap containing the CA bundle for TLS verification.|trusted-ca|false|
+|caTrustConfigMapKey|The key in the ConfigMap containing the CA bundle.|ca-bundle.crt|false|
+
+## Results
+|name|description|
+|---|---|
+|TEST_OUTPUT|Tekton task test output.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|workspace||false|
+
+## Additional info
+
+### Lifecycle Injection Workflow
+The task runs four steps in sequence:
+
+1. **check-lifecycle-eligibility** — determines whether the component is eligible for lifecycle injection (i.e. whether it targets OCP 5.0+) and writes the result to /shared/eligible.
+2. **get-packages** — if eligible, parses the `COPY`/`ADD` instructions in the Dockerfile and inspects the catalog subdirectories to determine which OLM packages require lifecycle injection.
+3. **generate-lifecycle** — runs `plcc2fbc` to fetch lifecycle data from PLCC and generate per-package `lifecycle.json` files.
+4. **inject-lifecycle** — injects the generated `lifecycle.json` files into the catalog source directories and writes the `TEST_OUTPUT` result.
+
+The task operates directly on the `workspace` PVC — the source tree under `<workspace>/source` is mutated in place, and any downstream task in the same pipeline that mounts the same workspace binding sees the injected lifecycle data without further steps. The pipeline author is responsible for ordering (e.g. `runAfter`) any task that needs to see the mutated tree, since Tekton does not infer task order from shared workspace usage the way it does from result references.
+
+### OCP Version Requirement
+Lifecycle injection only runs if **all** targeted OCP versions in the Dockerfile are >= 5.0. If any version is below 5.0, the component is not eligible, and the task exits successfully with no packages injected.
+
+### Partial Lifecycle Generation
+If `plcc2fbc` is unable to generate lifecycle data for one or more of the requested packages, the task fails rather than injecting a partial set of lifecycle files. The task only proceeds with injection once lifecycle data has been successfully generated for every requested package.
+
+### TEST_OUTPUT
+The task writes a `TEST_OUTPUT` result following the Konflux convention, allowing Conforma to evaluate the result without halting the pipeline. A `FAILURE` result is written if:
+
+- the eligibility check fails to produce output,
+- package discovery (`get-packages`) errors out,
+- the component is eligible but no packages requiring lifecycle injection are found,
+- `plcc2fbc` fails or cannot generate lifecycle data for all requested packages, or
+- lifecycle injection itself fails.
+
+A `SUCCESS` result is written if the component is not eligible for lifecycle injection.
+
+### Note
+
+This is the workspace-source variant; the Trusted Artifacts equivalent is `fbc-inject-lifecycle-oci-ta`.

--- a/task/fbc-inject-lifecycle/0.1/fbc-inject-lifecycle.yaml
+++ b/task/fbc-inject-lifecycle/0.1/fbc-inject-lifecycle.yaml
@@ -1,0 +1,268 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: fbc-inject-lifecycle
+spec:
+  description: >-
+    The fbc-inject-lifecycle task injects lifecycle data into a file-based catalog (FBC) component.
+    Checks whether the component is eligible for lifecycle injection (targets all OCP versions >= 5.0),
+    determines the target OLM packages from the Dockerfile, generates
+    lifecycle JSON files using plcc2fbc, and injects them into the
+    catalog source directories. If the component is not eligible, the task
+    succeeds without performing injection. If the component is eligible,
+    any failure to find packages, generate lifecycle data, or inject it
+    results in task failure.
+  params:
+    - default: .
+      description: Path to the directory to use as context.
+      name: CONTEXT
+      type: string
+    - default: ./Dockerfile
+      description: Path to the Dockerfile to build.
+      name: DOCKERFILE
+      type: string
+    - name: BUILD_ARGS
+      description: Array of --build-arg values ("arg=value" strings) used to
+        resolve ARG references in the base image tag.
+      type: array
+      default: []
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap containing the CA bundle for TLS verification.
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The key in the ConfigMap containing the CA bundle.
+      default: ca-bundle.crt
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+  volumes:
+    - name: shared
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /shared
+        name: shared
+      - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        name: trusted-ca
+        readOnly: true
+        subPath: ca-bundle.crt
+  steps:
+    - name: check-lifecycle-eligibility
+      image: quay.io/konflux-ci/operator-foundry:0.1@sha256:d83358368862108fcd3db9bf0241456bdf68cb1c77c6a4ca1a99bf0085094162 
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
+      workingDir: $(workspaces.workspace.path)/source
+      onError: continue
+      env:
+        - name: DOCKERFILE
+          value: $(params.DOCKERFILE)
+        - name: CONTEXT
+          value: $(params.CONTEXT)
+      args:
+        - "$(params.BUILD_ARGS[*])"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        BUILD_ARG_FLAGS=()
+        for build_arg in "$@"; do
+          BUILD_ARG_FLAGS+=(--build-arg "${build_arg}")
+        done
+
+        operator-foundry fbc check-lifecycle-eligibility \
+          --dockerfile "${DOCKERFILE}" \
+          --build-context "${CONTEXT}" \
+          "${BUILD_ARG_FLAGS[@]}" \
+          --output /shared/eligible
+
+        echo "[INFO] Component eligible for lifecycle injection (targets OCP 5.0+): $(cat /shared/eligible)"
+    - name: get-packages
+      image: quay.io/konflux-ci/operator-foundry:0.1@sha256:d83358368862108fcd3db9bf0241456bdf68cb1c77c6a4ca1a99bf0085094162
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
+      workingDir: $(workspaces.workspace.path)/source
+      onError: continue
+      env:
+        - name: DOCKERFILE
+          value: $(params.DOCKERFILE)
+        - name: CONTEXT
+          value: $(params.CONTEXT)
+      args:
+        - "$(params.BUILD_ARGS[*])"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ ! -s /shared/eligible ]] || [[ "$(cat /shared/eligible)" != "true" ]]; then
+          echo "[INFO] Not eligible for lifecycle injection (or eligibility check failed), skipping package extraction."
+          exit 0
+        fi
+
+        BUILD_ARG_FLAGS=()
+        for build_arg in "$@"; do
+          BUILD_ARG_FLAGS+=(--build-arg "${build_arg}")
+        done
+
+        operator-foundry fbc get-packages \
+          --dockerfile "${DOCKERFILE}" \
+          --build-context "${CONTEXT}" \
+          "${BUILD_ARG_FLAGS[@]}" \
+          --output /shared/packages.txt
+
+        if [[ ! -s /shared/packages.txt ]]; then
+          echo "[INFO] No packages requiring lifecycle injection found."
+        else
+          echo "[INFO] Packages to inject lifecycle for: $(cat /shared/packages.txt)"
+        fi
+    - name: generate-lifecycle
+      image: quay.io/konflux-ci/fbc-update-planner:0.1@sha256:7b8fea59f808ec8863fb9f0100f5d79d3b87820583c076219495f83a11abef86
+      computeResources:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+        limits:
+          memory: 256Mi
+      workingDir: $(workspaces.workspace.path)/source
+      onError: continue
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ ! -s /shared/packages.txt ]]; then
+          echo "[INFO] No packages to process, skipping lifecycle generation."
+          exit 0
+        fi
+
+        mkdir -p /shared/lifecycle
+
+        plcc2fbc --package "$(cat /shared/packages.txt)" --split /shared/lifecycle/
+    - name: inject-lifecycle
+      image: quay.io/konflux-ci/operator-foundry:0.1@sha256:d83358368862108fcd3db9bf0241456bdf68cb1c77c6a4ca1a99bf0085094162
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
+      workingDir: $(workspaces.workspace.path)/source
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: DOCKERFILE
+          value: $(params.DOCKERFILE)
+        - name: CONTEXT
+          value: $(params.CONTEXT)
+      args:
+        - "$(params.BUILD_ARGS[*])"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        BUILD_ARG_FLAGS=()
+        for build_arg in "$@"; do
+          BUILD_ARG_FLAGS+=(--build-arg "${build_arg}")
+        done
+
+        # Eligibility check step itself failed to run (script error), not a normal ineligible result.
+        ELIG_EXIT_CODE=$(cat /tekton/steps/step-check-lifecycle-eligibility/exitCode)
+        if [[ "$ELIG_EXIT_CODE" != "0" ]]; then
+          echo "[ERROR] Lifecycle eligibility check failed with exit code $ELIG_EXIT_CODE." >&2
+          note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        # Eligibility check ran but produced no output file - treat as a tooling failure.
+        if [[ ! -s /shared/eligible ]]; then
+          echo "[ERROR] Lifecycle eligibility check failed to produce output." >&2
+          note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        # Component does not target OCP 5.0+, so lifecycle injection is not required.
+        # This is expected/valid, not an error - report SUCCESS with zero successes.
+        if [[ "$(cat /shared/eligible)" != "true" ]]; then
+          echo "[INFO] Component not eligible for lifecycle injection (requires OCP 5.0+), skipping."
+          note="Task $(context.task.name) completed: Component not eligible for lifecycle injection (requires OCP 5.0+)."
+          operator-foundry make-result-json --result SUCCESS --successes 0 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        # get-packages step itself failed to run (script error), distinct from "no packages found" below.
+        GET_EXIT_CODE=$(cat /tekton/steps/step-get-packages/exitCode)
+        if [[ "$GET_EXIT_CODE" != "0" ]]; then
+          echo "[ERROR] get-packages step failed with exit code $GET_EXIT_CODE." >&2
+          note="Task $(context.task.name) failed: get-packages errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        # Eligible component but no target packages found - this is a hard failure,
+        # since eligible components are expected to always have packages.
+        if [[ ! -s /shared/packages.txt ]]; then
+          echo "[ERROR] Component is eligible for lifecycle injection but no packages were found." >&2
+          note="Task $(context.task.name) failed: Component eligible (OCP 5.0+) but no packages requiring lifecycle injection were found."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        # generate-lifecycle step itself failed to run (script error);
+        # plcc2fbc validation failures land here too since the script propagates plcc2fbc's exit code.
+        GEN_EXIT_CODE=$(cat /tekton/steps/step-generate-lifecycle/exitCode)
+        if [[ "$GEN_EXIT_CODE" != "0" ]]; then
+          echo "[ERROR] plcc2fbc generation failed with exit code $GEN_EXIT_CODE." >&2
+          note="Task $(context.task.name) failed: plcc2fbc generation errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        if ! operator-foundry fbc inject-lifecycle \
+          --dockerfile "${DOCKERFILE}" \
+          --build-context "${CONTEXT}" \
+          --packages "$(cat /shared/packages.txt)" \
+          --lifecycle-dir /shared/lifecycle/ \
+          "${BUILD_ARG_FLAGS[@]}"; then
+
+          # Injection itself failed despite valid packages and lifecycle data being available.
+          echo "[ERROR] Failed to inject lifecycle data" >&2
+          note="Task $(context.task.name) failed: lifecycle injection errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        note="Task $(context.task.name) completed: Lifecycle data injected successfully."
+        operator-foundry make-result-json --result SUCCESS --successes 1 --note "${note}" \
+          > "$(results.TEST_OUTPUT.path)"
+  workspaces:
+    - name: workspace

--- a/task/fbc-inject-lifecycle/CHANGELOG.md
+++ b/task/fbc-inject-lifecycle/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Initial version of `fbc-inject-lifecycle-oci-ta` task
+- Initial version of `fbc-inject-lifecycle` task
 - Checks whether a file-based catalog (FBC) component is eligible for lifecycle injection (targets OCP 5.0+)
 - Determines target OLM packages from the Dockerfile
 - Generates lifecycle JSON files using `plcc2fbc`
@@ -12,4 +12,4 @@
 
 ### Note
 
-This is the Trusted Artifacts variant of `fbc-inject-lifecycle` (`fbc-inject-lifecycle` uses a workspace source instead of `SOURCE_ARTIFACT`).
+Workspace-source variant; the Trusted Artifacts equivalent is `fbc-inject-lifecycle-oci-ta`.


### PR DESCRIPTION
Adds fbc-inject-lifecycle as the PVC-workspace counterpart to fbc-inject-lifecycle-oci-ta.
No SOURCE_ARTIFACT/ociStorage params, no use-trusted-artifact/create-trusted-artifact steps, a workspaces block instead, and workingDir pointed at $(workspaces.workspace.path)/source. 

Cross-links the CHANGELOG on both variants, matching the existing fbc-fips-check/-oci-ta convention.