### PR TITLE
CLOUDDST-32867: Add build-arg param to fbc-inject-lifecycle

### DIFF
--- a/task/fbc-inject-lifecycle-oci-ta/0.1/README.md
+++ b/task/fbc-inject-lifecycle-oci-ta/0.1/README.md
@@ -9,6 +9,7 @@ Lifecycle injection is skipped (with a successful result) if not all targeted OC
 |---|---|---|---|
 |CONTEXT|Path to the directory to use as context.|.|false|
 |DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|BUILD_ARGS|The array of --build-arg values ("arg=value" strings), passed to the check-lifecycle-eligibility, get-packages, and inject-lifecycle steps to resolve ARG references used in the Dockerfile's base image tag or in COPY/ADD source paths. Do not use for secrets, values are visible in TaskRun status, pod specs, and logs.|[]|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
 |ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|

--- a/task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
+++ b/task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
@@ -27,6 +27,14 @@ spec:
       description: Path to the Dockerfile to build.
       name: DOCKERFILE
       type: string
+    - name: BUILD_ARGS
+      description: The array of --build-arg values ("arg=value" strings), passed to
+        the check-lifecycle-eligibility, get-packages, and inject-lifecycle
+        steps to resolve ARG references used in the Dockerfile's base image
+        tag or in COPY/ADD source paths. Do not use for secrets, values are
+        visible in TaskRun status, pod specs, and logs.
+      type: array
+      default: []
     - name: ociArtifactExpiresAfter
       description: Expiration date for the trusted artifacts created in the
         OCI repository. An empty string means the artifacts do not expire.
@@ -80,7 +88,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: check-lifecycle-eligibility
-      image: quay.io/konflux-ci/operator-foundry:0.1@sha256:f6c0c59ac0891511c9edee848d138c63fa854327c2735f025fb86aa6666a0348
+      image: quay.io/konflux-ci/operator-foundry:0.1@sha256:70a3fceca8d568544d302750370dd6d7a31e4145ef45a062e8d2f11392365f76
       computeResources:
         requests:
           memory: 64Mi
@@ -94,18 +102,26 @@ spec:
           value: $(params.DOCKERFILE)
         - name: CONTEXT
           value: $(params.CONTEXT)
+      args:
+        - "$(params.BUILD_ARGS[*])"
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
 
+        BUILD_ARG_FLAGS=()
+        for build_arg in "$@"; do
+          BUILD_ARG_FLAGS+=(--build-arg "${build_arg}")
+        done
+
         operator-foundry fbc check-lifecycle-eligibility \
           --dockerfile "${DOCKERFILE}" \
           --build-context "${CONTEXT}" \
+          "${BUILD_ARG_FLAGS[@]}" \
           --output /shared/eligible
 
         echo "[INFO] Component eligible for lifecycle injection (targets OCP 5.0+): $(cat /shared/eligible)"
     - name: get-packages
-      image: quay.io/konflux-ci/operator-foundry:0.1@sha256:f6c0c59ac0891511c9edee848d138c63fa854327c2735f025fb86aa6666a0348
+      image: quay.io/konflux-ci/operator-foundry:0.1@sha256:70a3fceca8d568544d302750370dd6d7a31e4145ef45a062e8d2f11392365f76
       computeResources:
         requests:
           memory: 64Mi
@@ -119,6 +135,8 @@ spec:
           value: $(params.DOCKERFILE)
         - name: CONTEXT
           value: $(params.CONTEXT)
+      args:
+        - "$(params.BUILD_ARGS[*])"
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -128,9 +146,15 @@ spec:
           exit 0
         fi
 
+        BUILD_ARG_FLAGS=()
+        for build_arg in "$@"; do
+          BUILD_ARG_FLAGS+=(--build-arg "${build_arg}")
+        done
+
         operator-foundry fbc get-packages \
           --dockerfile "${DOCKERFILE}" \
           --build-context "${CONTEXT}" \
+          "${BUILD_ARG_FLAGS[@]}" \
           --output /shared/packages.txt
 
         if [[ ! -s /shared/packages.txt ]]; then
@@ -161,7 +185,7 @@ spec:
 
         plcc2fbc --package "$(cat /shared/packages.txt)" --split /shared/lifecycle/
     - name: inject-lifecycle
-      image: quay.io/konflux-ci/operator-foundry:0.1@sha256:f6c0c59ac0891511c9edee848d138c63fa854327c2735f025fb86aa6666a0348
+      image: quay.io/konflux-ci/operator-foundry:0.1@sha256:70a3fceca8d568544d302750370dd6d7a31e4145ef45a062e8d2f11392365f76
       computeResources:
         requests:
           memory: 64Mi
@@ -181,99 +205,105 @@ spec:
           value: $(params.CONTEXT)
         - name: SOURCE_ARTIFACT
           value: $(params.SOURCE_ARTIFACT)
-      command: ["/bin/bash", "-c"]
       args:
-        - |
-          #!/usr/bin/env bash
-          set -euo pipefail
+        - "$(params.BUILD_ARGS[*])"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
 
-          echo -n "${SOURCE_ARTIFACT}" > "$(results.SOURCE_ARTIFACT.path)"
+        BUILD_ARG_FLAGS=()
+        for build_arg in "$@"; do
+          BUILD_ARG_FLAGS+=(--build-arg "${build_arg}")
+        done
 
-          # Eligibility check step itself failed to run (script error), not a normal ineligible result.
-          ELIG_EXIT_CODE=$(cat /tekton/steps/step-check-lifecycle-eligibility/exitCode)
-          if [[ "$ELIG_EXIT_CODE" != "0" ]]; then
-            echo "[ERROR] Lifecycle eligibility check failed with exit code $ELIG_EXIT_CODE." >&2
-            note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
-            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-              > "$(results.TEST_OUTPUT.path)"
-            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-            exit 0
-          fi
+        echo -n "${SOURCE_ARTIFACT}" > "$(results.SOURCE_ARTIFACT.path)"
 
-          # Eligibility check ran but produced no output file - treat as a tooling failure.
-          if [[ ! -s /shared/eligible ]]; then
-            echo "[ERROR] Lifecycle eligibility check failed to produce output." >&2
-            note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
-            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-              > "$(results.TEST_OUTPUT.path)"
-            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-            exit 0
-          fi
-
-          # Component does not target OCP 5.0+, so lifecycle injection is not required.
-          # This is expected/valid, not an error - report SUCCESS with zero successes.
-          if [[ "$(cat /shared/eligible)" != "true" ]]; then
-            echo "[INFO] Component not eligible for lifecycle injection (requires OCP 5.0+), skipping."
-            note="Task $(context.task.name) completed: Component not eligible for lifecycle injection (requires OCP 5.0+)."
-            operator-foundry make-result-json --result SUCCESS --successes 0 --note "${note}" \
-              > "$(results.TEST_OUTPUT.path)"
-            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-            exit 0
-          fi
-
-          # get-packages step itself failed to run (script error), distinct from "no packages found" below.
-          GET_EXIT_CODE=$(cat /tekton/steps/step-get-packages/exitCode)
-          if [[ "$GET_EXIT_CODE" != "0" ]]; then
-            echo "[ERROR] get-packages step failed with exit code $GET_EXIT_CODE." >&2
-            note="Task $(context.task.name) failed: get-packages errors. Check logs."
-            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-              > "$(results.TEST_OUTPUT.path)"
-            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-            exit 0
-          fi
-
-          # Eligible component but no target packages found - this is a hard failure,
-          # since eligible components are expected to always have packages.
-          if [[ ! -s /shared/packages.txt ]]; then
-            echo "[ERROR] Component is eligible for lifecycle injection but no packages were found." >&2
-            note="Task $(context.task.name) failed: Component eligible (OCP 5.0+) but no packages requiring lifecycle injection were found."
-            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-              > "$(results.TEST_OUTPUT.path)"
-            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-            exit 0
-          fi
-
-          # generate-lifecycle step itself failed to run (script error);
-          # plcc2fbc validation failures land here too since the script propagates plcc2fbc's exit code.
-          GEN_EXIT_CODE=$(cat /tekton/steps/step-generate-lifecycle/exitCode)
-          if [[ "$GEN_EXIT_CODE" != "0" ]]; then
-            echo "[ERROR] plcc2fbc generation failed with exit code $GEN_EXIT_CODE." >&2
-            note="Task $(context.task.name) failed: plcc2fbc generation errors. Check logs."
-            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-              > "$(results.TEST_OUTPUT.path)"
-            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-            exit 0
-          fi
-
-          if ! operator-foundry fbc inject-lifecycle \
-            --dockerfile "${DOCKERFILE}" \
-            --build-context "${CONTEXT}" \
-            --packages "$(cat /shared/packages.txt)" \
-            --lifecycle-dir /shared/lifecycle/; then
-
-            # Injection itself failed despite valid packages and lifecycle data being available.
-            echo "[ERROR] Failed to inject lifecycle data" >&2
-            note="Task $(context.task.name) failed: lifecycle injection errors. Check logs."
-            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-              > "$(results.TEST_OUTPUT.path)"
-            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-            exit 0
-          fi
-
-          note="Task $(context.task.name) completed: Lifecycle data injected successfully."
-          operator-foundry make-result-json --result SUCCESS --successes 1 --note "${note}" \
+        # Eligibility check step itself failed to run (script error), not a normal ineligible result.
+        ELIG_EXIT_CODE=$(cat /tekton/steps/step-check-lifecycle-eligibility/exitCode)
+        if [[ "$ELIG_EXIT_CODE" != "0" ]]; then
+          echo "[ERROR] Lifecycle eligibility check failed with exit code $ELIG_EXIT_CODE." >&2
+          note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
             > "$(results.TEST_OUTPUT.path)"
-          echo -n "false" > "$(step.results.skip_create_trusted_artifact.path)"
+          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+          exit 0
+        fi
+
+        # Eligibility check ran but produced no output file - treat as a tooling failure.
+        if [[ ! -s /shared/eligible ]]; then
+          echo "[ERROR] Lifecycle eligibility check failed to produce output." >&2
+          note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+          exit 0
+        fi
+
+        # Component does not target OCP 5.0+, so lifecycle injection is not required.
+        # This is expected/valid, not an error - report SUCCESS with zero successes.
+        if [[ "$(cat /shared/eligible)" != "true" ]]; then
+          echo "[INFO] Component not eligible for lifecycle injection (requires OCP 5.0+), skipping."
+          note="Task $(context.task.name) completed: Component not eligible for lifecycle injection (requires OCP 5.0+)."
+          operator-foundry make-result-json --result SUCCESS --successes 0 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+          exit 0
+        fi
+
+        # get-packages step itself failed to run (script error), distinct from "no packages found" below.
+        GET_EXIT_CODE=$(cat /tekton/steps/step-get-packages/exitCode)
+        if [[ "$GET_EXIT_CODE" != "0" ]]; then
+          echo "[ERROR] get-packages step failed with exit code $GET_EXIT_CODE." >&2
+          note="Task $(context.task.name) failed: get-packages errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+          exit 0
+        fi
+
+        # Eligible component but no target packages found - this is a hard failure,
+        # since eligible components are expected to always have packages.
+        if [[ ! -s /shared/packages.txt ]]; then
+          echo "[ERROR] Component is eligible for lifecycle injection but no packages were found." >&2
+          note="Task $(context.task.name) failed: Component eligible (OCP 5.0+) but no packages requiring lifecycle injection were found."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+          exit 0
+        fi
+
+        # generate-lifecycle step itself failed to run (script error);
+        # plcc2fbc validation failures land here too since the script propagates plcc2fbc's exit code.
+        GEN_EXIT_CODE=$(cat /tekton/steps/step-generate-lifecycle/exitCode)
+        if [[ "$GEN_EXIT_CODE" != "0" ]]; then
+          echo "[ERROR] plcc2fbc generation failed with exit code $GEN_EXIT_CODE." >&2
+          note="Task $(context.task.name) failed: plcc2fbc generation errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+          exit 0
+        fi
+
+        if ! operator-foundry fbc inject-lifecycle \
+          --dockerfile "${DOCKERFILE}" \
+          --build-context "${CONTEXT}" \
+          --packages "$(cat /shared/packages.txt)" \
+          --lifecycle-dir /shared/lifecycle/ \
+          "${BUILD_ARG_FLAGS[@]}"; then
+
+          # Injection itself failed despite valid packages and lifecycle data being available.
+          echo "[ERROR] Failed to inject lifecycle data" >&2
+          note="Task $(context.task.name) failed: lifecycle injection errors. Check logs."
+          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+          exit 0
+        fi
+
+        note="Task $(context.task.name) completed: Lifecycle data injected successfully."
+        operator-foundry make-result-json --result SUCCESS --successes 1 --note "${note}" \
+          > "$(results.TEST_OUTPUT.path)"
+        echo -n "false" > "$(step.results.skip_create_trusted_artifact.path)"
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:3e6dc09d80042c78c0c3bbcb4faf91f493bffc45cdee0978f285a2e57ac8aebb
       when:

--- a/task/fbc-inject-lifecycle-oci-ta/CHANGELOG.md
+++ b/task/fbc-inject-lifecycle-oci-ta/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added optional `BUILD_ARGS` param, passed as `--build-arg` flags to the
+  `check-lifecycle-eligibility`, `get-packages`, and `inject-lifecycle` steps,
+  to resolve `ARG` references used in the base image tag or in COPY/ADD source
+  paths (requires `operator-foundry` with build-arg support in `check-lifecycle-eligibility`, `get-packages`
+  and `inject-lifecycle`).
+
+  Example: if your Dockerfile uses `ARG CATALOG_VERSION` in the `FROM` line,
+  or `ARG INPUT_DIR` in a `COPY` source path, pass their values via:
+
+```yaml
+  - name: BUILD_ARGS
+    value:
+      - CATALOG_VERSION=v5.0
+      - INPUT_DIR=catalog/v5.0
+```
+
+### Changed
+
+- Bumped the `operator-foundry` image digest to pick up build-arg support in
+  `check-lifecycle-eligibility`, `get-packages`, and `inject-lifecycle`.
+
 ## 0.1
 
 ### Added

--- a/task/validate-fbc/0.2/MIGRATION.md
+++ b/task/validate-fbc/0.2/MIGRATION.md
@@ -24,3 +24,14 @@ No action required. Review and merge the MintMaker PR once CI passes.
 
 If the migration script fails, manually add `fbc-inject-lifecycle` following the
 standard FBC pipeline blueprint in `build-definitions`.
+
+**Note:** The `fbc-inject-lifecycle-oci-ta` task accepts an optional
+`BUILD_ARGS` parameter (defaults to empty). If your Dockerfile uses
+`ARG` directives to parameterize the base image (`FROM`) or file paths
+in `COPY`/`ADD` instructions, add the parameter manually to your
+PipelineRun definition after merging, for example:
+
+     - name: BUILD_ARGS
+       value:
+         - "BASE_IMAGE=<your-base-image>"
+         - "CATALOG_DIR=my-catalog"


### PR DESCRIPTION
Add an optional BUILD_ARGS param to fbc-inject-lifecycle task in case product teams use ARGs in their Dockerfile that are resolved at build time.

In `inject-lifecycle` had to switch from command/args to script to support BUILD_ARGS. It would've been possible to keep command/args and still add BUILD_ARGS support, but it would've required that extra dummy positional argument to avoid silently dropping the first build-arg — an easy mistake to make and a subtle one to debug if missed.


### Risk Assesement
Low

We are just adding a new optional ARG, there is no logic change of what the task does.