### PR TITLE
Update tasks references due to Conforma failing

### DIFF
--- a/.tekton/fbc-inject-lifecycle-oci-ta-v01-pull-request.yaml
+++ b/.tekton/fbc-inject-lifecycle-oci-ta-v01-pull-request.yaml
@@ -230,7 +230,7 @@ spec:
         - name: name
           value: sast-shell-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:5e4586b010f0d09aeb1cf5a19502a601524ae28b7cad3eaf3c93a058bd9d1acc
         - name: kind
           value: task
         resolver: bundles
@@ -258,7 +258,7 @@ spec:
         - name: name
           value: sast-unicode-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:90efa582de7770d55102b74014a765cd16a25a56f2cf644b56a788c70c4dc749
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:eb9d5392f215cb8b52b16382098cac4885b1e6cd989f88ebd83fdb234d283eb9
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/fbc-inject-lifecycle-oci-ta-v01-push.yaml
+++ b/.tekton/fbc-inject-lifecycle-oci-ta-v01-push.yaml
@@ -227,7 +227,7 @@ spec:
         - name: name
           value: sast-shell-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:5e4586b010f0d09aeb1cf5a19502a601524ae28b7cad3eaf3c93a058bd9d1acc
         - name: kind
           value: task
         resolver: bundles
@@ -255,7 +255,7 @@ spec:
         - name: name
           value: sast-unicode-check-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:90efa582de7770d55102b74014a765cd16a25a56f2cf644b56a788c70c4dc749
+          value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:eb9d5392f215cb8b52b16382098cac4885b1e6cd989f88ebd83fdb234d283eb9
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
fbc-inject-lifecycle release failed due to Conforma:
```
Results:
✕ [Violation] tasks.required_untrusted_task_found
  ImageRef: quay.io/redhat-user-workloads/rhtap-integration-tenant/fbc-inject-lifecycle-oci-ta-v01@sha256:80eacb4b16b3ac9a564c609ff34c7d2fcb9d020f57ae6cbe7cf96c71541e860d
  Reason: Required task "sast-shell-check-oci-ta" is required and present but not from a trusted task
  Term: sast-shell-check-oci-ta
  Title: All required tasks are from trusted tasks
  Description: Ensure that the all required tasks are resolved from trusted tasks. To exclude this rule add
  "tasks.required_untrusted_task_found:sast-shell-check-oci-ta" to the `exclude` section of the policy configuration.
  Solution: Make sure all required tasks in the build pipeline are resolved from trusted tasks.
 
✕ [Violation] tasks.required_untrusted_task_found
  ImageRef: quay.io/redhat-user-workloads/rhtap-integration-tenant/fbc-inject-lifecycle-oci-ta-v01@sha256:80eacb4b16b3ac9a564c609ff34c7d2fcb9d020f57ae6cbe7cf96c71541e860d
  Reason: Required task "sast-unicode-check-oci-ta" is required and present but not from a trusted task
  Term: sast-unicode-check-oci-ta
  Title: All required tasks are from trusted tasks
  Description: Ensure that the all required tasks are resolved from trusted tasks. To exclude this rule add
  "tasks.required_untrusted_task_found:sast-unicode-check-oci-ta" to the `exclude` section of the policy configuration.
  Solution: Make sure all required tasks in the build pipeline are resolved from trusted tasks.
 
✕ [Violation] trusted_task.trusted
  ImageRef: quay.io/redhat-user-workloads/rhtap-integration-tenant/fbc-inject-lifecycle-oci-ta-v01@sha256:80eacb4b16b3ac9a564c609ff34c7d2fcb9d020f57ae6cbe7cf96c71541e860d
  Reason: Untrusted version of PipelineTask "sast-shell-check" (Task "sast-shell-check-oci-ta") was included in build chain
  comprised of: clone-repository, prefetch-dependencies, sast-shell-check. Please upgrade the task version to:
  sha256:5e4586b010f0d09aeb1cf5a19502a601524ae28b7cad3eaf3c93a058bd9d1acc
  Term: sast-shell-check-oci-ta
  Title: Tasks are trusted
  Description: Check the trust of the Tekton Tasks used in the build Pipeline. There are two modes in which trust is verified. The
  first mode is used if Trusted Artifacts are enabled. In this case, a chain of trust is established for all the Tasks involved in
  creating an artifact. If the chain contains an untrusted Task, then a violation is emitted. The second mode is used as a
  fallback when Trusted Artifacts are not enabled. In this case, **all** Tasks in the build Pipeline must be trusted. To exclude
  this rule add "trusted_task.trusted:sast-shell-check-oci-ta" to the `exclude` section of the policy configuration.
  Solution: If using Trusted Artifacts, be sure every Task in the build Pipeline responsible for producing a Trusted Artifact is
  trusted. Otherwise, ensure **all** Tasks in the build Pipeline are trusted. Note that trust is eventually revoked from Tasks
  when newer versions are made available.
 
✕ [Violation] trusted_task.trusted
  ImageRef: quay.io/redhat-user-workloads/rhtap-integration-tenant/fbc-inject-lifecycle-oci-ta-v01@sha256:80eacb4b16b3ac9a564c609ff34c7d2fcb9d020f57ae6cbe7cf96c71541e860d
  Reason: Untrusted version of PipelineTask "sast-unicode-check" (Task "sast-unicode-check-oci-ta") was included in build chain
  comprised of: clone-repository, prefetch-dependencies, sast-unicode-check. Please upgrade the task version to:
  sha256:eb9d5392f215cb8b52b16382098cac4885b1e6cd989f88ebd83fdb234d283eb9
  Term: sast-unicode-check-oci-ta
  Title: Tasks are trusted
  Description: Check the trust of the Tekton Tasks used in the build Pipeline. There are two modes in which trust is verified. The
  first mode is used if Trusted Artifacts are enabled. In this case, a chain of trust is established for all the Tasks involved in
  creating an artifact. If the chain contains an untrusted Task, then a violation is emitted. The second mode is used as a
  fallback when Trusted Artifacts are not enabled. In this case, **all** Tasks in the build Pipeline must be trusted. To exclude
  this rule add "trusted_task.trusted:sast-unicode-check-oci-ta" to the `exclude` section of the policy configuration.
  Solution: If using Trusted Artifacts, be sure every Task in the build Pipeline responsible for producing a Trusted Artifact is
  trusted. Otherwise, ensure **all** Tasks in the build Pipeline are trusted. Note that trust is eventually revoked from Tasks
  when newer versions are made available.
  ```
