### PR TITLE
Use command/arg instead of script as a workaround

### DIFF
--- a/task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
+++ b/task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
@@ -205,105 +205,109 @@ spec:
           value: $(params.CONTEXT)
         - name: SOURCE_ARTIFACT
           value: $(params.SOURCE_ARTIFACT)
+      command:
+        - /bin/bash
+        - -c
       args:
+        - |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          BUILD_ARG_FLAGS=()
+          for build_arg in "$@"; do
+            BUILD_ARG_FLAGS+=(--build-arg "${build_arg}")
+          done
+
+          echo -n "${SOURCE_ARTIFACT}" > "$(results.SOURCE_ARTIFACT.path)"
+
+          # Eligibility check step itself failed to run (script error), not a normal ineligible result.
+          ELIG_EXIT_CODE=$(cat /tekton/steps/step-check-lifecycle-eligibility/exitCode)
+          if [[ "$ELIG_EXIT_CODE" != "0" ]]; then
+            echo "[ERROR] Lifecycle eligibility check failed with exit code $ELIG_EXIT_CODE." >&2
+            note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
+            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+              > "$(results.TEST_OUTPUT.path)"
+            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+            exit 0
+          fi
+
+          # Eligibility check ran but produced no output file - treat as a tooling failure.
+          if [[ ! -s /shared/eligible ]]; then
+            echo "[ERROR] Lifecycle eligibility check failed to produce output." >&2
+            note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
+            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+              > "$(results.TEST_OUTPUT.path)"
+            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+            exit 0
+          fi
+
+          # Component does not target OCP 5.0+, so lifecycle injection is not required.
+          # This is expected/valid, not an error - report SUCCESS with zero successes.
+          if [[ "$(cat /shared/eligible)" != "true" ]]; then
+            echo "[INFO] Component not eligible for lifecycle injection (requires OCP 5.0+), skipping."
+            note="Task $(context.task.name) completed: Component not eligible for lifecycle injection (requires OCP 5.0+)."
+            operator-foundry make-result-json --result SUCCESS --successes 0 --note "${note}" \
+              > "$(results.TEST_OUTPUT.path)"
+            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+            exit 0
+          fi
+
+          # get-packages step itself failed to run (script error), distinct from "no packages found" below.
+          GET_EXIT_CODE=$(cat /tekton/steps/step-get-packages/exitCode)
+          if [[ "$GET_EXIT_CODE" != "0" ]]; then
+            echo "[ERROR] get-packages step failed with exit code $GET_EXIT_CODE." >&2
+            note="Task $(context.task.name) failed: get-packages errors. Check logs."
+            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+              > "$(results.TEST_OUTPUT.path)"
+            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+            exit 0
+          fi
+
+          # Eligible component but no target packages found - this is a hard failure,
+          # since eligible components are expected to always have packages.
+          if [[ ! -s /shared/packages.txt ]]; then
+            echo "[ERROR] Component is eligible for lifecycle injection but no packages were found." >&2
+            note="Task $(context.task.name) failed: Component eligible (OCP 5.0+) but no packages requiring lifecycle injection were found."
+            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+              > "$(results.TEST_OUTPUT.path)"
+            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+            exit 0
+          fi
+
+          # generate-lifecycle step itself failed to run (script error);
+          # plcc2fbc validation failures land here too since the script propagates plcc2fbc's exit code.
+          GEN_EXIT_CODE=$(cat /tekton/steps/step-generate-lifecycle/exitCode)
+          if [[ "$GEN_EXIT_CODE" != "0" ]]; then
+            echo "[ERROR] plcc2fbc generation failed with exit code $GEN_EXIT_CODE." >&2
+            note="Task $(context.task.name) failed: plcc2fbc generation errors. Check logs."
+            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+              > "$(results.TEST_OUTPUT.path)"
+            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+            exit 0
+          fi
+
+          if ! operator-foundry fbc inject-lifecycle \
+            --dockerfile "${DOCKERFILE}" \
+            --build-context "${CONTEXT}" \
+            --packages "$(cat /shared/packages.txt)" \
+            --lifecycle-dir /shared/lifecycle/ \
+            "${BUILD_ARG_FLAGS[@]}"; then
+
+            # Injection itself failed despite valid packages and lifecycle data being available.
+            echo "[ERROR] Failed to inject lifecycle data" >&2
+            note="Task $(context.task.name) failed: lifecycle injection errors. Check logs."
+            operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
+              > "$(results.TEST_OUTPUT.path)"
+            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+            exit 0
+          fi
+
+          note="Task $(context.task.name) completed: Lifecycle data injected successfully."
+          operator-foundry make-result-json --result SUCCESS --successes 1 --note "${note}" \
+            > "$(results.TEST_OUTPUT.path)"
+          echo -n "false" > "$(step.results.skip_create_trusted_artifact.path)"
+        - "bash"
         - "$(params.BUILD_ARGS[*])"
-      script: |
-        #!/usr/bin/env bash
-        set -euo pipefail
-
-        BUILD_ARG_FLAGS=()
-        for build_arg in "$@"; do
-          BUILD_ARG_FLAGS+=(--build-arg "${build_arg}")
-        done
-
-        echo -n "${SOURCE_ARTIFACT}" > "$(results.SOURCE_ARTIFACT.path)"
-
-        # Eligibility check step itself failed to run (script error), not a normal ineligible result.
-        ELIG_EXIT_CODE=$(cat /tekton/steps/step-check-lifecycle-eligibility/exitCode)
-        if [[ "$ELIG_EXIT_CODE" != "0" ]]; then
-          echo "[ERROR] Lifecycle eligibility check failed with exit code $ELIG_EXIT_CODE." >&2
-          note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
-          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-            > "$(results.TEST_OUTPUT.path)"
-          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-          exit 0
-        fi
-
-        # Eligibility check ran but produced no output file - treat as a tooling failure.
-        if [[ ! -s /shared/eligible ]]; then
-          echo "[ERROR] Lifecycle eligibility check failed to produce output." >&2
-          note="Task $(context.task.name) failed: lifecycle eligibility check errors. Check logs."
-          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-            > "$(results.TEST_OUTPUT.path)"
-          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-          exit 0
-        fi
-
-        # Component does not target OCP 5.0+, so lifecycle injection is not required.
-        # This is expected/valid, not an error - report SUCCESS with zero successes.
-        if [[ "$(cat /shared/eligible)" != "true" ]]; then
-          echo "[INFO] Component not eligible for lifecycle injection (requires OCP 5.0+), skipping."
-          note="Task $(context.task.name) completed: Component not eligible for lifecycle injection (requires OCP 5.0+)."
-          operator-foundry make-result-json --result SUCCESS --successes 0 --note "${note}" \
-            > "$(results.TEST_OUTPUT.path)"
-          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-          exit 0
-        fi
-
-        # get-packages step itself failed to run (script error), distinct from "no packages found" below.
-        GET_EXIT_CODE=$(cat /tekton/steps/step-get-packages/exitCode)
-        if [[ "$GET_EXIT_CODE" != "0" ]]; then
-          echo "[ERROR] get-packages step failed with exit code $GET_EXIT_CODE." >&2
-          note="Task $(context.task.name) failed: get-packages errors. Check logs."
-          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-            > "$(results.TEST_OUTPUT.path)"
-          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-          exit 0
-        fi
-
-        # Eligible component but no target packages found - this is a hard failure,
-        # since eligible components are expected to always have packages.
-        if [[ ! -s /shared/packages.txt ]]; then
-          echo "[ERROR] Component is eligible for lifecycle injection but no packages were found." >&2
-          note="Task $(context.task.name) failed: Component eligible (OCP 5.0+) but no packages requiring lifecycle injection were found."
-          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-            > "$(results.TEST_OUTPUT.path)"
-          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-          exit 0
-        fi
-
-        # generate-lifecycle step itself failed to run (script error);
-        # plcc2fbc validation failures land here too since the script propagates plcc2fbc's exit code.
-        GEN_EXIT_CODE=$(cat /tekton/steps/step-generate-lifecycle/exitCode)
-        if [[ "$GEN_EXIT_CODE" != "0" ]]; then
-          echo "[ERROR] plcc2fbc generation failed with exit code $GEN_EXIT_CODE." >&2
-          note="Task $(context.task.name) failed: plcc2fbc generation errors. Check logs."
-          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-            > "$(results.TEST_OUTPUT.path)"
-          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-          exit 0
-        fi
-
-        if ! operator-foundry fbc inject-lifecycle \
-          --dockerfile "${DOCKERFILE}" \
-          --build-context "${CONTEXT}" \
-          --packages "$(cat /shared/packages.txt)" \
-          --lifecycle-dir /shared/lifecycle/ \
-          "${BUILD_ARG_FLAGS[@]}"; then
-
-          # Injection itself failed despite valid packages and lifecycle data being available.
-          echo "[ERROR] Failed to inject lifecycle data" >&2
-          note="Task $(context.task.name) failed: lifecycle injection errors. Check logs."
-          operator-foundry make-result-json --result FAILURE --failures 1 --note "${note}" \
-            > "$(results.TEST_OUTPUT.path)"
-          echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
-          exit 0
-        fi
-
-        note="Task $(context.task.name) completed: Lifecycle data injected successfully."
-        operator-foundry make-result-json --result SUCCESS --successes 1 --note "${note}" \
-          > "$(results.TEST_OUTPUT.path)"
-        echo -n "false" > "$(step.results.skip_create_trusted_artifact.path)"
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:3e6dc09d80042c78c0c3bbcb4faf91f493bffc45cdee0978f285a2e57ac8aebb
       when:

--- a/task/fbc-inject-lifecycle-oci-ta/CHANGELOG.md
+++ b/task/fbc-inject-lifecycle-oci-ta/CHANGELOG.md
@@ -25,6 +25,19 @@
 - Bumped the `operator-foundry` image digest to pick up build-arg support in
   `check-lifecycle-eligibility`, `get-packages`, and `inject-lifecycle`.
 
+### Fixed
+
+- Changed the `inject-lifecycle` step from `script:` to `command`/`args`.
+  This step declares both a task-level result and a step-level result
+  (`skip_create_trusted_artifact`); on Tekton Pipelines versions that predate
+  the fix for [tektoncd/pipeline#8255](https://github.com/tektoncd/pipeline/issues/8255)
+  (fixed by [#10007](https://github.com/tektoncd/pipeline/pull/10007)), that
+  combination trips a validation webhook bug when read from a step's
+  `script:` field, causing the Task to be rejected admission with a
+  "non-existent variable" error. Tekton's step-results validator only
+  inspects `script`, not `command`/`args`, so moving the script there avoids
+  the bug without changing behavior.
+
 ## 0.1
 
 ### Added


### PR DESCRIPTION
## Summary

Change the `inject-lifecycle` step of `fbc-inject-lifecycle-oci-ta` (0.1) from
`script:` to `command`/`args`, to avoid tripping a Tekton Pipelines admission
webhook bug on clusters that haven't picked up the fix yet.

## Background: why this is failing

`fbc-inject-lifecycle-oci-ta`'s `inject-lifecycle` step declares **both**:

- a task-level `spec.results` block (`SOURCE_ARTIFACT`, `TEST_OUTPUT`), and
- a step-level `results:` block on the step itself (`skip_create_trusted_artifact`,
  written via `$(step.results.skip_create_trusted_artifact.path)`)

On clusters where the installed Tekton Pipelines controller predates
[tektoncd/pipeline#10007](https://github.com/tektoncd/pipeline/pull/10007)
(fix for [tektoncd/pipeline#8255](https://github.com/tektoncd/pipeline/issues/8255)),
this combination trips a validation bug: the admission webhook
(`validation.webhook.pipeline.tekton.dev`) incorrectly rejects the whole Task
as containing a "non-existent variable" in the step's script, even though
`$(step.results...)` is valid syntax. Any PipelineRun that resolves this task
bundle fails at admission with:

> Couldn't retrieve Task "resolver type bundles\nname = fbc-inject-lifecycle-oci-ta\n":
> validation failed for referenced object fbc-inject-lifecycle-oci-ta: admission webhook
> "validation.webhook.pipeline.tekton.dev" denied the request: validation failed:
> non-existent variable in "...": spec.steps[4].script

This was confirmed by comparing two PipelineRuns pinned to the **identical**
`fbc-inject-lifecycle-oci-ta:0.1` bundle digest: one on a Konflux prod tenant
(fails with the error above) and one on stage (runs fine) — same Task content,
different Tekton controller behind the two admission webhooks, so the defect
is environment/version-dependent, not a typo in the task itself.

Root-caused in upstream `tektoncd/pipeline`
(`pkg/apis/pipeline/v1/task_validation.go`): the offending validator,
`ValidateStepResultsVariables(ctx, results, script)`, is only ever called with
`s.Script` — it never inspects `s.Command` or `s.Args`. Every other step in
this task that mixes step + task results correctly avoids the bug simply
because it doesn't use `script:` (see `run-opm-command-oci-ta`, which uses
the same step-results pattern via `command`/`args` and has never hit this).

This will be fixed for all Konflux prod clusters on August 7th. I'd like to go ahead with this workaround in order for the product team to start using the task.


Verified that the task in now passing on Konflux `stone-prd-rh01` cluster.