### PR TITLE
CLOUDDST-32905: Use validators none in plcc2fbc call

### DIFF
--- a/task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
+++ b/task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
@@ -163,7 +163,7 @@ spec:
           echo "[INFO] Packages to inject lifecycle for: $(cat /shared/packages.txt)"
         fi
     - name: generate-lifecycle
-      image: quay.io/konflux-ci/fbc-update-planner:0.1@sha256:7b8fea59f808ec8863fb9f0100f5d79d3b87820583c076219495f83a11abef86
+      image: quay.io/konflux-ci/fbc-update-planner:0.1.0@sha256:756516302435356d73911a79e2de2ef20a8adf4296009c5aa2b521563e1610dd
       computeResources:
         requests:
           memory: 256Mi
@@ -183,7 +183,7 @@ spec:
 
         mkdir -p /shared/lifecycle
 
-        plcc2fbc --package "$(cat /shared/packages.txt)" --split /shared/lifecycle/
+        plcc2fbc --validators none --package "$(cat /shared/packages.txt)" --split /shared/lifecycle/
     - name: inject-lifecycle
       image: quay.io/konflux-ci/operator-foundry:0.1@sha256:70a3fceca8d568544d302750370dd6d7a31e4145ef45a062e8d2f11392365f76
       computeResources:

--- a/task/fbc-inject-lifecycle-oci-ta/CHANGELOG.md
+++ b/task/fbc-inject-lifecycle-oci-ta/CHANGELOG.md
@@ -25,6 +25,12 @@
 - Bumped the `operator-foundry` image digest to pick up build-arg support in
   `check-lifecycle-eligibility`, `get-packages`, and `inject-lifecycle`.
 
+- Bumped the `generate-lifecycle` step image (`quay.io/konflux-ci/fbc-update-planner`)
+  to `0.1.0@sha256:756516302435356d73911a79e2de2ef20a8adf4296009c5aa2b521563e1610dd`.
+
+- Passed `--validators none` to `plcc2fbc` in the `generate-lifecycle` step, so
+  lifecycle generation no longer runs PLCC validators.
+
 ### Fixed
 
 - Changed the `inject-lifecycle` step from `script:` to `command`/`args`.


### PR DESCRIPTION
The Operator Update Planner GA criteria is 30 selected operators passing the new task and getting lifecycle data injected in the catalog. Currently most of the operators are failing the PLCC data validation. It was decided to use `--validators none` to completely drop PLCC filtering, and only use FBC validation/filtering by default. That way more operators will pass the task and bring us closer to the overall goal of GA criteria.

JIRA: https://redhat.atlassian.net/browse/CLOUDDST-32905

### Risk Assessment

Low

Loosening the strict PLCC validator so more packages pass plcc2fbc filtering.