### PR TITLE
Update fips stepAction to konflux-test:v1.5.6 and check-payload 0.3.17

### DIFF
--- a/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+++ b/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
@@ -21,7 +21,7 @@ spec:
   results:
     - name: TEST_OUTPUT
       description: Tekton task test output.
-  image: quay.io/konflux-ci/konflux-test:v1.5.3@sha256:37299834a7a95c042e2d9bc24d0668ccfc8dd4c96baf1339a0f3f46915e91455
+  image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
   securityContext:
     capabilities:
       add:


### PR DESCRIPTION
Updated fips stepAction to use konflux-test:v1.5.6, which has check-payload 0.3.17.
