### PR TITLE
Update fips tasks to use check-payload 0.3.17

### DIFF
--- a/task/fbc-fips-check-matrix-based-oci-ta/0.1/fbc-fips-check-matrix-based-oci-ta.yaml
+++ b/task/fbc-fips-check-matrix-based-oci-ta/0.1/fbc-fips-check-matrix-based-oci-ta.yaml
@@ -47,7 +47,7 @@ spec:
         - $(params.BUCKETS_ARTIFACT)=/var/workdir/buckets
 
     - name: prepare-bucket-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       env:
         - name: BUCKET_INDEX
           value: $(params.BUCKET_INDEX)
@@ -111,13 +111,13 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/konflux-operator-tasks
           - name: revision
-            value: 908cb431fd008e0d16a158e620ee1dc0ca3098b5
+            value: 318c537c071e5320919927fafdd495534a753b88
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git
 
     - name: output-results
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       env:
         - name: BUCKET_INDEX
           value: $(params.BUCKET_INDEX)

--- a/task/fbc-fips-check-matrix-based-oci-ta/CHANGELOG.md
+++ b/task/fbc-fips-check-matrix-based-oci-ta/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.17`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -48,7 +48,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -325,12 +325,12 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/konflux-operator-tasks
           - name: revision
-            value: 908cb431fd008e0d16a158e620ee1dc0ca3098b5
+            value: 318c537c071e5320919927fafdd495534a753b88
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       env:
         - name: STEP_ACTION_TEST_OUTPUT
           value: $(steps.fips-operator-check-step-action.results.TEST_OUTPUT)

--- a/task/fbc-fips-check-oci-ta/CHANGELOG.md
+++ b/task/fbc-fips-check-oci-ta/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Replace the ad-hoc 4-line minor-version arithmetic with a call to the shared `get_prev_ocp_version()` helper now available in `utils.sh` (`konflux-test:v1.5.0`). The helper correctly handles the v5.0 → v4.22 cross-major boundary.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.17`.
 
 ## 0.1
 

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -38,7 +38,7 @@ spec:
       description: Images processed in the task.
   steps:
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       computeResources:
         requests:
           memory: 6Gi
@@ -314,12 +314,12 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/konflux-operator-tasks
           - name: revision
-            value: 908cb431fd008e0d16a158e620ee1dc0ca3098b5
+            value: 318c537c071e5320919927fafdd495534a753b88
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       computeResources:
         requests:
           memory: 64Mi

--- a/task/fbc-fips-check/CHANGELOG.md
+++ b/task/fbc-fips-check/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.17`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
 - Replace the ad-hoc 4-line minor-version arithmetic with a call to the shared `get_prev_ocp_version()` helper now available in `utils.sh` (`konflux-test:v1.5.0`). The helper correctly handles the v5.0 → v4.22 cross-major boundary.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -54,7 +54,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -166,12 +166,12 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/konflux-operator-tasks
           - name: revision
-            value: 908cb431fd008e0d16a158e620ee1dc0ca3098b5
+            value: 318c537c071e5320919927fafdd495534a753b88
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       script: |
         #!/usr/bin/env bash
         set -euo pipefail

--- a/task/fips-operator-bundle-check-oci-ta/CHANGELOG.md
+++ b/task/fips-operator-bundle-check-oci-ta/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.17`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -29,7 +29,7 @@ spec:
       description: Images processed in the task.
   steps:
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       computeResources:
         limits:
           memory: 12Gi
@@ -140,12 +140,12 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/konflux-operator-tasks
           - name: revision
-            value: 908cb431fd008e0d16a158e620ee1dc0ca3098b5
+            value: 318c537c071e5320919927fafdd495534a753b88
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
+      image: quay.io/konflux-ci/konflux-test:v1.5.6@sha256:365b172d2a8a145406f028d0a94a77b489fbdf9d84e5bd9529b1c3ad72f077b1
       computeResources:
         limits:
           memory: 64Mi

--- a/task/fips-operator-bundle-check/CHANGELOG.md
+++ b/task/fips-operator-bundle-check/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.17`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 


### PR DESCRIPTION
Updated fips tasks to use check-payload 0.3.17.

Closes: [KFLUXSPRT-8535](https://redhat.atlassian.net/browse/KFLUXSPRT-8535)


[KFLUXSPRT-8535]: https://redhat.atlassian.net/browse/KFLUXSPRT-8535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Risk Assessment 

Low
