### PR TITLE
Pin GitHub Actions to commit digests

### DIFF
--- a/.github/workflows/check-kustomize-build.yaml
+++ b/.github/workflows/check-kustomize-build.yaml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        # actions/checkout@v4.4.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Install oc
         run: |
           set -euo pipefail

--- a/.github/workflows/check-ta.yaml
+++ b/.github/workflows/check-ta.yaml
@@ -10,12 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        # actions/checkout@v4.4.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Check Trusted Artifact variants
         id: check
         run: hack/generate-ta-tasks.sh
         if: ${{ always() && steps.check.conclusion == 'failure' }}
-        uses: actions/upload-artifact@v4
+        # actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: Trusted artifacts patch
           path: ./ta.patch

--- a/.github/workflows/check-task-migration.yaml
+++ b/.github/workflows/check-task-migration.yaml
@@ -9,14 +9,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        # actions/checkout@v4.4.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.12.0
+        # helm/kind-action@v1.12.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3
         with:
           cluster_name: kind
-      - uses: tektoncd/actions/setup-tektoncd@main
+      # tektoncd/actions/setup-tektoncd@main
+      - uses: tektoncd/actions/setup-tektoncd@2b126ef971bbfda195d8a6c9b7c4eb3bfda452bf
         with:
           pipeline_version: latest
       - name: Run check

--- a/.github/workflows/check-task-yamls.yaml
+++ b/.github/workflows/check-task-yamls.yaml
@@ -12,17 +12,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        # actions/checkout@v4.4.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.12.0
+        # helm/kind-action@v1.12.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3
         with:
           cluster_name: kind
 
       - name: Set up Tekton
-        uses: tektoncd/actions/setup-tektoncd@main
+        # tektoncd/actions/setup-tektoncd@main
+        uses: tektoncd/actions/setup-tektoncd@2b126ef971bbfda195d8a6c9b7c4eb3bfda452bf
         with:
           pipeline_version: latest
 

--- a/.github/workflows/checkton.yaml
+++ b/.github/workflows/checkton.yaml
@@ -10,14 +10,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        # actions/checkout@v4.4.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           # Differential Checkton requires full git history
           fetch-depth: 0
 
       - name: Run Checkton
         id: checkton
-        uses: chmeliik/checkton@v0.4.0
+        # chmeliik/checkton@v0.4.0
+        uses: chmeliik/checkton@c24110a11ba3d4acb90964be57fc1177fed2918f
         with:
           # Set to false when re-enabling SARIF uploads
           fail-on-findings: true

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -84,7 +84,8 @@ jobs:
           cache-dependency-path: ./${{matrix.path}}/go.sum
       # https://github.com/securego/gosec/blob/12be14859bc7d4b956b71bef0b443694aa519d8a/README.md#integrating-with-code-scanning
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        # securego/gosec@master
+        uses: securego/gosec@2eb4727ebc7504944ddbcdd2f7157db492026c3f
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-tags normal,periodic -no-fail -fmt sarif -out results.sarif ${{matrix.path}}/...'

--- a/.github/workflows/run-task-tests.yaml
+++ b/.github/workflows/run-task-tests.yaml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout build-defintions Repository
-        uses: actions/checkout@v4
+        # actions/checkout@v4.4.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: "${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}"
           path: build-definitions
@@ -58,7 +59,8 @@ jobs:
 
       - name: Checkout konflux-ci/konflux-ci Repository
         if: steps.tasks-to-be-tested.outputs.tasklist != ''
-        uses: actions/checkout@v4
+        # actions/checkout@v4.4.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           repository: 'konflux-ci/konflux-ci'
           path: konflux-ci
@@ -66,7 +68,8 @@ jobs:
 
       - name: Create k8s Kind Cluster
         if: steps.tasks-to-be-tested.outputs.tasklist != ''
-        uses: helm/kind-action@v1
+        # helm/kind-action@v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc
         with:
           config: konflux-ci/kind-config.yaml
 

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -9,6 +9,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4.4.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Lint YAML files
         run: yamllint .


### PR DESCRIPTION
Replace floating action tags (@v4, @v1, @main, @master) with resolved SHAs and add comments documenting the
original action versions for easier verification.

Assisted-by: Cursor, Composer 2.5

Issue: CLOUDDST-32935

## Risk Assessment

Low